### PR TITLE
Fix focus from top level scene to child level scene

### DIFF
--- a/examples/pxScene2d/src/jsbindings/rcvrcore/AppSceneContext.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/AppSceneContext.js
@@ -62,12 +62,6 @@ AppSceneContext.prototype.loadScene = function() {
 
   this.loadPackage(fullPath);
 
-  ///this._scene.setFocus(innerscene); //fails - crashes with no error report
-  //container.setFocus(innerscene); // does not work - container does not contain setFocus
-  //innerscene.setFocus(container);  // does not work - no errors
-
-  this.rootScene.setFocus(this.container);  // works - enables child scene to work and get key events
-
   this.container.on('onKeyDown', function (e) {
     log.message(2, "container(" + this.packageUrl + "): keydown:" + e.keyCode);
   }.bind(this));

--- a/examples/pxScene2d/src/jsbindings/rcvrcore/SceneManager.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/SceneManager.js
@@ -34,6 +34,7 @@ SceneManager.prototype.createNewAppContext = function(params) {
     }
 
     appSceneContext.loadScene();
+    params.rootScene.setFocus(params.sceneContainer);
     log.message(2, "  push app Scene context");
     this.sceneStack.push(appSceneContext);
   } else {


### PR DESCRIPTION
Isolate setting initial focus only to top level scene container and not child scene containers when scenes-by-url are created.