### PR TITLE
Modifications for requests brought up at during our onsite meetings

### DIFF
--- a/examples/pxScene2d/src/jsbindings/rcvrcore/XModule.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/XModule.js
@@ -69,10 +69,6 @@ XModule.prototype.getModuleExports = function(moduleName) {
   }
 }
 
-function prepareModule(requiredModuleSet, readyCallBack, failedCallback, params) {
-  this.prepareModule(requiredModuleSet, readyCallBack, failedCallback, params);
-}
-
 function importModule(requiredModuleSet, params) {
   return this.importModule(requiredModuleSet, params);
 }
@@ -80,7 +76,7 @@ function importModule(requiredModuleSet, params) {
 XModule.prototype.importModule = function(requiredModuleSet, params) {
   var _this = this;
   return new Promise(function(resolve, reject) {
-    _this.prepareModule(requiredModuleSet, function readyCallback(importsArr) {
+    _this._importModule(requiredModuleSet, function readyCallback(importsArr) {
       resolve(importsArr);
     }) ,
       function failureCallback(error) {
@@ -89,7 +85,7 @@ XModule.prototype.importModule = function(requiredModuleSet, params) {
   } );
 }
 
-XModule.prototype.prepareModule = function(requiredModuleSet, readyCallBack, failedCallback, params) {
+XModule.prototype._importModule = function(requiredModuleSet, readyCallBack, failedCallback, params) {
 
   if( readyCallBack == 'undefined' ) {
     console.trace("WARNING: " + 'prepareModule was did not have resolutionCallback parameter: USAGE: prepareModule(requiredModules, readyCallback, [failedCallback])');
@@ -169,6 +165,7 @@ XModule.prototype.prepareModule = function(requiredModuleSet, readyCallBack, fai
 
     // Now wait for all the include/import promises to be fulfilled
     Promise.all(_this.promises).then(function (exports) {
+      var exportsMap = {};
       var exportsArr = [];
       for (var k = 0; k < _this.moduleNameList.length; ++k) {
         var ptn = pathToNameMap;
@@ -178,11 +175,12 @@ XModule.prototype.prepareModule = function(requiredModuleSet, readyCallBack, fai
         _this.appSandbox[pathToNameMap[exports[k][1]]] = exports[k][0];
         _this.moduleData[_this.moduleNameList[k]]= exports[k][0];
         exportsArr[k] = exports[k][0];
+        exportsMap[pathToNameMap[exports[k][1]]] = exports[k][0];
         //console.log("TJC: " + _this.name + " gets: module[" + _this.moduleNameList[k] + "]: " + exports[k][0]);
       }
       log.message(7, "XMODULE ABOUT TO NOTIFY [" + _this.name + "] that all its imports are Ready");
       if( readyCallBack != null && readyCallBack != 'undefined' ) {
-        readyCallBack(exportsArr);
+        readyCallBack(exportsMap);
       }
       moduleBuildResolve();
       log.message(8, "XMODULE AFTER NOTIFY [" + _this.name + "] that all its imports are Ready");
@@ -201,7 +199,6 @@ XModule.prototype.prepareModule = function(requiredModuleSet, readyCallBack, fai
 }
 
 module.exports = {
-  prepareModule: prepareModule,
   importModule: importModule,
   XModule: XModule
 };

--- a/examples/pxScene2d/src/jsbindings/rcvrcore/pxRoot.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/pxRoot.js
@@ -22,7 +22,7 @@ var VirtualKeyCode = {UNKNOWN:0, ENTER:13, PAGE_UP:33, PAGE_DOWN:34, LEFT:37, RI
 
 
 // The singleton instance of pxRoot
-var pxRoot = null;
+var pxroot = null;
 
 // The public XRE system APIs
 var XreSysApis = {
@@ -31,7 +31,7 @@ var XreSysApis = {
   }
 }
 
-function PxRoot(baseUri) {
+function pxRoot(baseUri) {
   this.rootScene = null;
   // only one child scene at the root level for now
   this.childScene = null;
@@ -39,7 +39,7 @@ function PxRoot(baseUri) {
   this.fpsBg = null;
 }
 
-PxRoot.prototype.initialize = function(x, y, width, height) {
+pxRoot.prototype.initialize = function(x, y, width, height) {
   this.rootScene = px.getScene(x, y, width, height);
 
   this.rootScene.root.on('onPreKeyDown', function (e) {
@@ -128,7 +128,7 @@ PxRoot.prototype.initialize = function(x, y, width, height) {
 
 };
 
-PxRoot.prototype.showFpsView = function(show) {
+pxRoot.prototype.showFpsView = function(show) {
   if( show && this.fpsBg === null ) {
     this.fpsBg = this.rootScene.createRectangle({fillColor: 0x00000080, lineColor: 0xffff0080,lineWidth: 3,x: 10,y: 10,a: 0, parent: this.rootScene.root });
     var fpsCounter = this.rootScene.createText({x: 5,textColor: 0xffffffff,pixelSize: 24,text: "0fps",parent: this.fpsBg });
@@ -150,7 +150,7 @@ PxRoot.prototype.showFpsView = function(show) {
   }
 }
 
-PxRoot.prototype.createNewAppContext = function(params) {
+pxRoot.prototype.createNewAppContext = function(params) {
   log.message(2, "Create New Scene Context: url=" + params.packageUrl);
 
   var appSceneContext = new AppSceneContext(params);
@@ -178,7 +178,7 @@ function getVirtualKeyCode(keyCode, flags) {
 }
 
 
-PxRoot.prototype.addScene = function(params) {
+pxRoot.prototype.addScene = function(params) {
   if( this.rootScene == null ) {
     console.error("Root scene has not been created.  Has PxRoot been initialized?");
     return null;
@@ -197,14 +197,14 @@ PxRoot.prototype.addScene = function(params) {
   return this.childScene;
 };
 
-PxRoot.prototype.setOriginalUrl = function(origUrl) {
+pxRoot.prototype.setOriginalUrl = function(origUrl) {
   this.originalUrl = origUrl;
 }
 
 module.exports = function(x, y, width, height) {
-  pxRoot = new PxRoot();
-  pxRoot.initialize(x, y, width, height);
-  return pxRoot;
+  pxroot = new pxRoot();
+  pxroot.initialize(x, y, width, height);
+  return pxroot;
 };
 
 

--- a/examples/pxScene2d/src/jsbindings/rcvrcore/utils/FileArchive.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/utils/FileArchive.js
@@ -79,7 +79,7 @@ FileArchive.prototype.addFile = function(filename, contents) {
 FileArchive.prototype.loadRemoteJarFile = function(filePath) {
   var _this = this;
   return new Promise(function (resolve, reject) {
-    var req = http.get(url.parse("http://localhost/.../file.zip"), function (res) {
+    var req = http.get(url.parse(filePath), function (res) {
       if (res.statusCode !== 200) {
         console.log(res.statusCode);
         reject("http get error. statusCode=" + res.statusCode);
@@ -126,6 +126,11 @@ FileArchive.prototype.loadLocalJarFile = function(jarFilePath) {
     });
   });
 };
+
+FileArchive.prototype.loadFromJarData = function(dataBuf) {
+  var jar = new JSZip(dataBuf);
+  this.processJar(jar);
+}
 
 FileArchive.prototype.processJar = function(jar) {
   for(var file in jar.files) {


### PR DESCRIPTION
1) Allow autosensing of jar versus JavaScript files.
2) Added new px.import mechanism to pass resolved imports as a single object that contains all resolved exports per name.
3) Force users of px.import to hardcode use of '.js' instead of allowing it to be appended like Node require() does.  This was requested during our onsite meetings.
4) Renamed PxRoot to pxRoot per John's request.
5) Miscellaneous code cleanup