### PR TITLE
Modified PxRoot to now be pxRoot per JR's request

### DIFF
--- a/examples/pxScene2d/src/jsbindings/start.js
+++ b/examples/pxScene2d/src/jsbindings/start.js
@@ -3,7 +3,8 @@ var setLoggingLevel = require('rcvrcore/Logger').setLoggingLevel;
 var argDefinitions = {screenWidth:{required:false, default:1280, help:"Specifies the screen width"},
   screenHeight:{required:false, default:720, help:"Specifies the screen height"},
   logLevel:{required:false, default:1, help:"Specifies the logging level (0-N)"},
-  url:{required:true, help:"Specifies JavaScript file to load"}
+  url:{required:true, help:"Specifies JavaScript file to load"},
+  useNodeBasedImports:{required:false, help:"If true then imports don't need to specify file extensions"}
 };
 
 var argProcessor = require("rcvrcore/utils/ArgProcessor");
@@ -14,7 +15,8 @@ if( processArgs.hasOwnProperty('logLevel')) {
 }
 
 // Create root object and send it the base URI of the xre2 framework modules
-var pxRoot = require('rcvrcore/PxRoot')(0, 0, processArgs['screenWidth'], processArgs['screenHeight']);
+var pxRoot = require('rcvrcore/pxRoot')(0, 0, processArgs['screenWidth'], processArgs['screenHeight']);
 
-pxRoot.addScene({url:processArgs['url'],w:processArgs['screenWidth'],h:processArgs['screenHeight']});
+pxRoot.addScene({url:processArgs['url'],w:processArgs['screenWidth'],h:processArgs['screenHeight'],
+  useNodeBasedImports:processArgs['useNodeBasedImports']});
 pxRoot.setOriginalUrl(processArgs['url']);


### PR DESCRIPTION
PxRoot is now pxRoot.
Also, temporarily includes an optional command line argument to still allow Node style imports that don't specify '.js'.   This is to temporarily allow some existing tests to work.   This value defaults to false.