### PR TITLE
Per onsite meeting agreements, these changes implement module relative path for px.import

### DIFF
--- a/examples/pxScene2d/src/jsbindings/rcvrcore/SceneModuleLoader.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/SceneModuleLoader.js
@@ -13,6 +13,7 @@ var loadFile = require('rcvrcore/utils/FileUtils').loadFile;
 function SceneModuleLoader() {
   this.fileArchive = null;
   this.manifest = null;
+  this.loadedJarFile = false;
   this.defaultManifest = false;
 }
 
@@ -30,7 +31,8 @@ SceneModuleLoader.prototype.loadScenePackage = function(fileSpec) {
           reject();
         }
       }).catch(function onError(err) {
-        console.log("error on http get: " + err);
+        console.error("SceneModuleLoader#loadScenePackage: error on http get of " + filePath + ": Error=" + err);
+        reject(err);
       });
     } else {
       _this.loadLocalFile(filePath).then(function dataAvailable(data) {
@@ -41,7 +43,8 @@ SceneModuleLoader.prototype.loadScenePackage = function(fileSpec) {
           reject();
         }
       }).catch(function onError(err) {
-        console.log("error on file get: " + err);
+        console.error("SceneModuleLoader#loadScenePackage: error on file get: " + err);
+        reject(err);
       });
     }
   });
@@ -64,7 +67,7 @@ SceneModuleLoader.prototype.loadRemoteFile = function(filePath) {
   return new Promise(function (resolve, reject) {
     var req = http.get(url.parse(filePath), function (res) {
       if (res.statusCode !== 200) {
-        console.log(res.statusCode);
+        console.error(res.statusCode);
         reject("http get error. statusCode=" + res.statusCode);
       }
       var data = [], dataLen = 0;
@@ -107,60 +110,6 @@ SceneModuleLoader.prototype.loadLocalFile = function(filePath) {
 };
 
 
-SceneModuleLoader.prototype.loadScenePackageOld = function(scenePackage) {
-  var _this = this;
-
-  return new Promise(function (resolve, reject) {
-    if (scenePackage == null || scenePackage === 'undefined' || scenePackage.fileUri === null
-      || scenePackage.fileUri === 'undefined') {
-      reject("loadScenePackage: package spec doesn't contain fileUri!");
-    }
-    var hasManifest = false;
-    if (scenePackage.manifest != null && scenePackage.manifest != 'undefined') {
-      hasManifest = true;
-    }
-
-    _this.fileArchive = new FileArchive('SceneModule');
-
-    if (hasExtension(scenePackage.fileUri, '.jar') ) {
-      _this.fileArchive.loadFromJarFile(scenePackage.fileUri).then(function () {
-        (_this.processFileArchive() == 0)? resolve() : reject();
-      }).catch(function (error) {
-        reject("Error loading tar file: " + error)
-      });
-    } else if (hasManifest && hasExtension(scenePackage.fileUri, '.js')) {
-      loadFile(scenePackage.manifest).then(function (fileContents) {
-        _this.fileArchive.addFile('package.json', fileContents);
-        return loadFile(scenePackage.fileUri);
-      }).then(function (fileContents) {
-        _this.fileArchive.addFile(scenePackage.fileUri, fileContents);
-        (_this.processFileArchive() == 0)? resolve() : reject();
-      }).catch(function (error) {
-        reject("Json and JavaScript loading Error: " + error)
-      });
-
-    } else if (hasExtension(scenePackage.fileUri, '.js')) {
-      loadFile(scenePackage.fileUri).then(function (fileContents) {
-        _this.fileArchive.addFile('package.json', "{ \"main\" : \"" + scenePackage.fileUri + "\" }");
-        _this.fileArchive.addFile(scenePackage.fileUri, fileContents);
-        _this.defaultManifest = true;
-
-        if(_this.processFileArchive() == 0) {
-          resolve();
-        } else {
-          reject();
-        }
-
-      }).catch(function(){
-        reject("Did not find file: " + scenePackage.fileUri);
-      });
-    } else {
-      reject("Unknown file extension: " + scenePackage.fileUri);
-    }
-  });
-
-}
-
 SceneModuleLoader.prototype.processFileArchive = function() {
   if( this.fileArchive.getFileCount() >= 2 ) {
     var packageFileContents = this.fileArchive.getFileContents("package.json");
@@ -190,6 +139,10 @@ SceneModuleLoader.prototype.getManifest = function() {
 
 SceneModuleLoader.prototype.isDefaultManifest = function() {
   return this.defaultManifest;
+}
+
+SceneModuleLoader.prototype.jarFileWasLoaded = function() {
+  return this.loadedJarFile;
 }
 
 module.exports = SceneModuleLoader;

--- a/examples/pxScene2d/src/jsbindings/rcvrcore/XModule.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/XModule.js
@@ -5,7 +5,7 @@ var hasExtension = require('rcvrcore/utils/FileUtils').hasExtension;
 var Logger = require('rcvrcore/Logger').Logger;
 var log = new Logger('XModule');
 
-function XModule(name, appSceneContext) {
+function XModule(name, appSceneContext, fromJarFile, basePath) {
   log.message(5, "Create new XModule for " + name);
   this.name = name;
   this.appSandbox = null;
@@ -18,6 +18,8 @@ function XModule(name, appSceneContext) {
   this.appSceneContext = appSceneContext;
   this.imports = {};
   this.log = null;
+  this.fromJarFile = fromJarFile;
+  this.basePath = basePath;
 }
 
 XModule.prototype.load = function(uri) {
@@ -26,6 +28,9 @@ XModule.prototype.load = function(uri) {
 
 }
 
+XModule.prototype.getBasePath = function() {
+  return this.basePath;
+}
 
 XModule.prototype.initSandbox = function(otherSandbox) {
   this.appSandbox = otherSandbox;

--- a/examples/pxScene2d/src/jsbindings/rcvrcore/utils/FileArchive.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/utils/FileArchive.js
@@ -11,13 +11,21 @@ var log = new Logger('FileUtils');
 
 var tarDirectory = {};
 
-function FileArchive(name) {
-  this.name = name;
+function FileArchive(filePath) {
+  this.filePath = filePath;
+  this.baseFilePath = filePath.substring(0, filePath.lastIndexOf('/'));
   this.numEntries = 0;
   this.directory = {};
   this.jar = null;
 }
 
+FileArchive.prototype.getFilePath = function() {
+  return this.filePath;
+}
+
+FileArchive.prototype.getBaseFilePath = function() {
+  return this.baseFilePath;
+}
 
 FileArchive.prototype.loadFromJarFile = function(filePath) {
   var _this = this;
@@ -60,6 +68,7 @@ FileArchive.prototype.getFileContents = function(filename) {
   if( this.directory.hasOwnProperty(filename) ) {
     return this.directory[filename];
   } else {
+    console.error("No file contents in [" + this.baseFilePath + "] for " + filename);
     return null;
   }
 }
@@ -81,7 +90,6 @@ FileArchive.prototype.loadRemoteJarFile = function(filePath) {
   return new Promise(function (resolve, reject) {
     var req = http.get(url.parse(filePath), function (res) {
       if (res.statusCode !== 200) {
-        console.log(res.statusCode);
         reject("http get error. statusCode=" + res.statusCode);
       }
       var data = [], dataLen = 0;
@@ -130,6 +138,7 @@ FileArchive.prototype.loadLocalJarFile = function(jarFilePath) {
 FileArchive.prototype.loadFromJarData = function(dataBuf) {
   var jar = new JSZip(dataBuf);
   this.processJar(jar);
+  this.loadedJarFile = true;
 }
 
 FileArchive.prototype.processJar = function(jar) {


### PR DESCRIPTION
Added support for relative paths and per module base path.
Cleaned out old public class support.
Improved error percolation on promise failures.

Tested against:
   receiver files and jar file on our Amazon server.
   receiver files and jar file on localhost
   local filesystem gallery in ./examples/
   local filesystem browser.js
