### PR TITLE
Added new support for px:scene.1.js import.  Also, reorganization of namespaces.

### DIFF
--- a/examples/pxScene2d/src/jsbindings/browser.js
+++ b/examples/pxScene2d/src/jsbindings/browser.js
@@ -1,4 +1,4 @@
-
+px.import("px:scene.1.js").then( function ready(scene) {
 var root = scene.root;
 var bg = scene.create({t:"image",url:"../../images/status_bg.png",parent:root,xStretch:1,yStretch:1});
 var inputbg = scene.create({t:"image9",a:0.9,url:"../../images/input2.png",x:10,y:10,w:400,lInset:10,rInset:10,tInset:10,bInset:10,parent:bg});
@@ -102,3 +102,8 @@ scene.on("onResize", function(e) { updateSize(e.w,e.h); });
 updateSize(scene.w,scene.h);
 
 scene.setFocus(inputbg);
+
+}).catch( function importFailed(err){
+  console.error("Import failed for browser.js: " + err)
+});
+

--- a/examples/pxScene2d/src/jsbindings/rcvrcore/SceneModuleLoader.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/SceneModuleLoader.js
@@ -18,6 +18,7 @@ function SceneModuleLoader() {
 }
 
 SceneModuleLoader.prototype.loadScenePackage = function(fileSpec) {
+  log.message(4, "loadScenePackage - fileSpec.fileUri=" + fileSpec.fileUri);
   var _this = this;
   var filePath = fileSpec.fileUri;
 
@@ -35,6 +36,9 @@ SceneModuleLoader.prototype.loadScenePackage = function(fileSpec) {
         reject(err);
       });
     } else {
+      if( filePath.substring(0,5) === 'file:' ) {
+        filePath = filePath.substring(5);
+      }
       _this.loadLocalFile(filePath).then(function dataAvailable(data) {
         _this.processFileData(filePath, data);
         if(_this.processFileArchive() == 0) {

--- a/examples/pxScene2d/src/jsbindings/rcvrcore/scene.1.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/scene.1.js
@@ -1,0 +1,129 @@
+function Scene() {
+  var nativeScene = null;
+  var stylePatterns = [];
+
+  this._setNativeScene = function(scene, filePath) {
+    if( nativeScene === null ) {
+      nativeScene = scene;
+      this.PX_LINEAR = scene.PX_LINEAR;
+      this.PX_EXP1 = scene.PX_EXP1;
+      this.PX_EXP2 = scene.PX_EXP2;
+      this.PX_EXP3 = scene.PX_EXP3;
+      this.PX_LOOP = scene.PX_LOOP;
+      this.PX_SEESAW = scene.PX_SEESAW;
+      this.PX_STOP = scene.PX_STOP;
+      this.PX_INQUAD = scene.PX_INQUAD;
+      this.PX_INCUBIC = scene.PX_INCUBIC;
+      this.PX_INBACK = scene.PX_INBACK;
+      this.PX_EASEINELASTIC = scene.PX_EASEINELASTIC;
+      this.PX_EASEOUTELASTIC = scene.PX_EASEOUTELASTIC;
+      this.PX_EASEOUTBOUNCE = scene.PX_EASEOUTBOUNCE;
+      this.PX_END = scene.PX_END;
+      this.allInterpolators = scene.allInterpolators;
+      this.root = scene.root;
+      this.filePath = filePath;
+      this.w = scene.w;
+      this.h = scene.h;
+    }
+  }
+
+  this.getX = function() { return nativeScene.x; };
+  this.getY = function() {
+    return nativeScene.y; };
+
+  this.getWidth = function() {
+    return nativeScene.w; };
+  this.getHeight = function() {
+    return nativeScene.h; };
+
+  this.create = function create(params) {
+    applyStyle.call(this, params);
+
+    return nativeScene.create(params);
+  }
+
+  this.createRectangle = function(params) {
+    return nativeScene.createRectangle(params)
+  }
+
+  this.createText = function(params) {
+    return nativeScene.createText(params)
+  }
+
+  this.createImage = function(params) {
+    return nativeScene.createImage(params)
+  }
+
+  this.createImage9 = function(params) {
+    return nativeScene.createImage9(params);
+  }
+
+  //TODO - what is createExternal used for?  Testing only?
+  this.createExternal = function(params) {
+    if( params.parent === undefined ) {
+      params.parent = nativeScene.root;
+    }
+    return nativeScene.createExternal(params);
+  }
+
+  this.createScene = function(params) {
+    if( params.parent === undefined ) {
+      params.parent = nativeScene.root;
+    }
+    return nativeScene.createScene(params);
+  }
+
+  this.setFocus = function(element) {
+    return nativeScene.setFocus(element);
+  }
+
+  this.on = function(eventType, func) {
+    return nativeScene.on(eventType, func);
+  }
+
+  this.defineStyle = function(paramMatchSet, styleParams) {
+    var entry = [paramMatchSet,styleParams];
+    stylePatterns.push([paramMatchSet,styleParams]);
+  }
+
+  function applyStyle(createParams) {
+    var currentMatch = null;
+    var currentKeysMatched = 0;
+
+    for(var currentPatternSet=0; currentPatternSet < stylePatterns.length; ++currentPatternSet) {
+      var patternSet = stylePatterns[currentPatternSet];
+      var patternMatchSet = patternSet[0];
+      var patternParams = patternSet[1];
+      var allKeysMatched = true;
+      var totalKeysMatched = 0;
+      for (var patternKey in patternMatchSet) {
+        if( !createParams.hasOwnProperty(patternKey) ) {
+          // don't consider this set anymore
+          allKeysMatched = false;
+          break;
+        } else {
+          ++totalKeysMatched;
+        }
+      }
+      if( allKeysMatched ) {
+        if( totalKeysMatched > currentKeysMatched ) {
+          currentMatch = patternParams;
+        }
+      }
+    }
+
+    if( currentMatch !== null ) {
+      for(var key in currentMatch ) {
+        if( !createParams.hasOwnProperty(key) ) {
+          createParams[key] = currentMatch[key];
+        }
+      }
+    }
+
+  }
+
+  return this;
+}
+
+module.exports = Scene;
+

--- a/examples/pxScene2d/src/jsbindings/rcvrcore/utils/FileUtils.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/utils/FileUtils.js
@@ -30,18 +30,24 @@ function loadFile(fileUri) {
               log.message(3, "Got file[" + fileUri + "] from web service");
               resolve(code);
             } else {
-              log.error("FAILED to read file[" + fileUri + "] from web service");
+              log.error("StatusCode Bad: FAILED to read file[" + fileUri + "] from web service");
               reject(res.statusCode);
             }
           });
         });
         req.on('error', function (err) {
-          log.error("FAILED to read file[" + fileUri + "] from web service");
+          log.error("Error: FAILED to read file[" + fileUri + "] from web service");
           reject(err);
         });
       }
     }
     else {
+      if( fileUri.substring(0,5) === 'file:' ) {
+        fileUri = fileUri.substring(5);
+        if( fileUri.substring(0,2) === '//') {
+          fileUri = fileUri.substring(1);
+        }
+      }
       var infile = fs.createReadStream(fileUri);
       infile.on('data', function (data) {
         code += data;


### PR DESCRIPTION
Added new scene.1.js wrapper for nativeScene.
Added new support for style pattern matching, through scene.1.js
New support for px:scene1.js import.  Note the the nativeScene is no longer part of the app sandbox context.  Scene is now picked up using px.import( ...px:scene.1.js... ).

Reorganize variable variables and methods into px namespace from app and module.