### PR TITLE
Added new px:scene.1-based support for RPC per getRPCContext spec

### DIFF
--- a/examples/pxScene2d/src/jsbindings/rcvrcore/AppSceneContext.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/AppSceneContext.js
@@ -15,6 +15,7 @@ var log = new Logger('AppSceneContext');
 function AppSceneContext(params) { // container, innerscene, packageUrl) {
   this.container = params.sceneContainer;
   this.innerscene = params.scene;
+  this.rpcController = params.rpcController;
   if( params.packageUrl.indexOf('?') != -1 ) {
     var urlParts = url.parse(params.packageUrl, true);
     this.queryParams = urlParts.query;
@@ -416,6 +417,7 @@ AppSceneContext.prototype.include = function(filePath, currentXModule) {
         _this.sceneWrapper = new Scene();
       }
       _this.sceneWrapper._setNativeScene(_this.innerscene, currentXModule.name);
+      _this.sceneWrapper._setRPCController(_this.rpcController);
       onImportComplete([_this.sceneWrapper, origFilePath]);
       return;
     }

--- a/examples/pxScene2d/src/jsbindings/rcvrcore/pxRoot.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/pxRoot.js
@@ -10,6 +10,7 @@ if ( typeof(getScene) == 'undefined' )
 
 var fs = require("fs");
 var AppSceneContext = require('rcvrcore/AppSceneContext');
+var RPCController = require('rcvrcore/rpcController');
 
 var Logger = require('rcvrcore/Logger').Logger;
 var log = new Logger('XModule');
@@ -37,6 +38,7 @@ function pxRoot(baseUri) {
   this.childScene = null;
   this.originalUrl = 'browser.js';
   this.fpsBg = null;
+  this.rpcController = new RPCController();
 }
 
 pxRoot.prototype.initialize = function(x, y, width, height) {
@@ -117,7 +119,7 @@ pxRoot.prototype.initialize = function(x, y, width, height) {
         log.info("onScene: New scene is second level: url=" + url);
       }
 
-      self.createNewAppContext({sceneContainer:container, scene:innerscene, packageUrl:url});
+      self.createNewAppContext({sceneContainer:container, scene:innerscene, packageUrl:url, rpcController:self.rpcController});
 
     }, 10);
   }

--- a/examples/pxScene2d/src/jsbindings/rcvrcore/rpcContext.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/rpcContext.js
@@ -1,0 +1,98 @@
+/**
+ * Created by tjcarroll2
+ * on 2/6/16.
+ */
+
+function RPCContext(theScene) {
+  var scene = theScene;
+  var rpcController = null;
+  var sourceTargetName;
+  var appNameTargetRegistered = false;
+  var functions = {};
+  var onRPCCall;
+
+  this.registerApp = function(targetName) {
+    if( rpcController !== null && !appNameTargetRegistered ) {
+      appNameTargetRegistered = rpcController.registerApp(targetName, scene);
+      sourceTargetName = targetName;
+    } else {
+      console.error("RPC registerApp: No rpcController exists or target app is already registered for " + targetName + ", rpcController=" + rpcController);
+    }
+
+    return appNameTargetRegistered;
+  };
+
+  this.onRPCCall = function(callback) {
+    onRPCCall = callback;
+  };
+
+  this.registerFunction = function(functionName, domainFiltersArray) {
+    if( rpcController !== null || !appNameTargetRegistered ) {
+      functions[functionName] = domainFiltersArray;
+      return true;
+    } else {
+      console.error("No rpcController exists or target  for registering function " + appNameTargetRegistered);
+    }
+
+    return false;
+  };
+
+  this.execute = function(remoteTargetName, functionName, args, callback) {
+    if( rpcController !== null ) {
+      rpcController.execute(sourceTargetName, remoteTargetName, functionName, args, callback);
+    } else {
+      console.error("No rpcController for executing RPC function " + remoteTargetName + ":" + functionName);
+    }
+  };
+
+  this._execute = function(sourceTarget, remoteTargetName, functionName, args) {
+    if( !functions.hasOwnProperty(functionName) ) {
+      console.error("RPC execute: function name<" + functionName + "> doesn't exist in target <" + remoteTargetName + ">");
+      return false;
+    }
+
+    if( !isSourceDomainAllowed(sourceTarget, functions[functionName]) ) {
+      console.error("RPC execute: function name<" + functionName + "> doesn't allow calls from sourceTarget domain <" + sourceTarget + ">");
+      return false;
+    }
+
+    return onRPCCall(functionName, args);
+
+  };
+
+  function isSourceDomainAllowed(sourceTarget, domainFiltersArray) {
+    if( domainFiltersArray === undefined || domainFiltersArray === null || domainFiltersArray.length == 0
+      || (domainFiltersArray.length === 1 && domainFiltersArray[0][1] === "*") ) {
+      return true;
+    }
+
+    var lastDotIndex = sourceTarget.lastIndexOf('.');
+    if( lastDotIndex === -1 ) {
+      // default packages aren't allowed
+      return false;
+    }
+
+    // include the dot
+    var baseDomain = sourceTarget.substring(0, lastDotIndex+1);
+
+    for (var index = 0; index < domainFiltersArray.length; ++index) {
+      var filter = domainFiltersArray[index][1] + ".";
+      if( filter.length <= baseDomain.length  ) {
+        var sourceDomainStart = baseDomain.substring(0, filter.length);
+        if( filter === sourceDomainStart ) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+
+  }
+
+  this._setRPCController = function(rpcCtlr) {
+    rpcController = rpcCtlr;
+  }
+
+}
+
+module.exports = RPCContext;

--- a/examples/pxScene2d/src/jsbindings/rcvrcore/rpcController.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/rpcController.js
@@ -1,0 +1,31 @@
+/**
+ * Created by tjcarroll2
+ * on 2/6/16.
+ */
+
+function RPCController() {
+  var registeredApps = {};
+
+  this.registerApp = function(targetName, scene) {
+    if( registeredApps.hasOwnProperty(targetName) ) {
+      console.error("RPC registerApp:  App name RPC target already exists for  " + targetName);
+      return false;
+    }
+    registeredApps[targetName] = scene;
+  };
+
+  this.execute = function(sourceTarget, remoteTargetName, functionName, args, callback) {
+    if( !registeredApps.hasOwnProperty(remoteTargetName) ) {
+      console.error("RPC execute: App name RPC target doesn't exist for  " + remoteTargetName);
+      return false;
+    }
+
+    var rtnValue = registeredApps[remoteTargetName].getRPCContext()._execute(sourceTarget, remoteTargetName, functionName, args);
+    if( callback !== undefined && callback !== null ) {
+      callback(rtnValue);
+    }
+  }
+}
+
+module.exports = RPCController;
+

--- a/examples/pxScene2d/src/jsbindings/rcvrcore/scene.1.js
+++ b/examples/pxScene2d/src/jsbindings/rcvrcore/scene.1.js
@@ -1,6 +1,9 @@
+var RPCContext = require('rcvrcore/rpcContext');
+
 function Scene() {
   var nativeScene = null;
   var stylePatterns = [];
+  var rpcContext = new RPCContext(this);
 
   this._setNativeScene = function(scene, filePath) {
     if( nativeScene === null ) {
@@ -15,6 +18,14 @@ function Scene() {
       this.w = scene.w;
       this.h = scene.h;
     }
+  }
+
+  this._setRPCController = function(rpcController) {
+    rpcContext._setRPCController(rpcController);
+  }
+
+  this.getRPCContext = function getRPCContext() {
+    return rpcContext;
   }
 
   this.loadArchive = function(u) {


### PR DESCRIPTION
px:scene.1-based support for RPC per getRPCContext spec.
rpc = scene.getRPCContext();
rpc.registerApp(appNamespace);
rpc.registerFunction(functionName, filters);
rpc.execute(appId, functionName, args, callback);