### PR TITLE
Fixing a crash/memory corruption

### DIFF
--- a/src/pxPixels.h
+++ b/src/pxPixels.h
@@ -6,6 +6,7 @@
 #define PX_PIXELS_H
 
 #include "pxCore.h"
+#include <stdint.h>
 
 struct pxPixel {
 
@@ -53,7 +54,7 @@ struct pxPixel {
             unsigned char b: 8;
 #endif
         };
-        unsigned long u;
+        uint32_t u;
     };
 };
 


### PR DESCRIPTION
When iterating with p++, in pxBuffer::fill, the assumption is to have 4-byte increment, which is not always true for "long" values