### PR TITLE
Refactor pxWayland as a pxIView

### DIFF
--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -59,12 +59,6 @@ void stopProfiling()
 }
 #endif //ENABLE_VALGRIND
 
-#define WAYLAND_EVENT( event, target, ...) \
-  pxWayland *wayland= dynamic_cast<pxWayland*>((pxObject*)(target)); \
-  if ( wayland ) { \
-     wayland->event( __VA_ARGS__ ); \
-  }
-
 static char encoding_table[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
                                 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
                                 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
@@ -1071,7 +1065,7 @@ pxScene2d::pxScene2d(bool top)
   mPointerHotSpotX= 40;
   mPointerHotSpotY= 16;
   mPointerHidden= false;
-  mPointerTextureCacheObj.setURL("cursor.png");
+  mPointerResource= pxImageManager::getImage("cursor.png");
   #endif
 }
 
@@ -1228,10 +1222,11 @@ rtError pxScene2d::createExternal(rtObjectRef p, rtObjectRef& o)
 
 rtError pxScene2d::createWayland(rtObjectRef p, rtObjectRef& o)
 {
-  o = new pxWayland(this);
+  rtRefT<pxWaylandContainer> c = new pxWaylandContainer(this);
+  c->setView(new pxWayland);
+  o = c.getPtr();
   o.set(p);
   o.send("init");
-
   return RT_OK;
 }
 
@@ -1292,7 +1287,7 @@ void pxScene2d::draw()
   #ifdef USE_SCENE_POINTER
   if (mPointerTexture.getPtr() == NULL)
   {
-    mPointerTexture = mPointerTextureCacheObj.getTexture();
+    mPointerTexture= ((rtImageResource*)mPointerResource.getPtr())->getTexture();
     if (mPointerTexture.getPtr() != NULL)
     {
       mPointerW = mPointerTexture->width();
@@ -1457,7 +1452,6 @@ void pxScene2d::onMouseDown(int32_t x, int32_t y, uint32_t flags)
       #if 0
       hit->mEmit.send("onMouseDown", e);
       #else
-      WAYLAND_EVENT( onMouseDown, hit );
       bubbleEvent(e,hit,"onPreMouseDown","onMouseDown");
       #endif
     }
@@ -1503,7 +1497,6 @@ void pxScene2d::onMouseUp(int32_t x, int32_t y, uint32_t flags)
         #if 0
         hit->mEmit.send("onMouseUp", e);
         #else
-        WAYLAND_EVENT( onMouseUp, hit );
         bubbleEvent(e,hit,"onPreMouseUp","onMouseUp");
         #endif
       }
@@ -1529,7 +1522,6 @@ void pxScene2d::setMouseEntered(pxObject* o)
       #if 0
       mMouseEntered->mEmit.send("onMouseLeave", e);
       #else
-      WAYLAND_EVENT( onMouseLeave, mMouseEntered );
       bubbleEvent(e,mMouseEntered,"onPreMouseLeave","onMouseLeave");
       #endif
     }
@@ -1544,7 +1536,6 @@ void pxScene2d::setMouseEntered(pxObject* o)
       #if 0
       mMouseEntered->mEmit.send("onMouseEnter", e);
       #else
-      WAYLAND_EVENT( onMouseEnter, mMouseEntered );
       bubbleEvent(e,mMouseEntered,"onPreMouseEnter","onMouseEnter");
       #endif
     }
@@ -1722,7 +1713,6 @@ void pxScene2d::onMouseMove(int32_t x, int32_t y)
     e.set("target", mMouseDown.getPtr());
     e.set("x", to.x());
     e.set("y", to.y());
-    WAYLAND_EVENT( onMouseMove, mMouseDown, to.x(), to.y() );
     bubbleEvent(e, mMouseDown, "onPreMouseMove", "onMouseMove");
 #endif
     }
@@ -1756,7 +1746,6 @@ void pxScene2d::onMouseMove(int32_t x, int32_t y)
 #if 0
       hit->mEmit.send("onMouseMove",e);
 #else
-      WAYLAND_EVENT( onMouseMove, hit, hitPt.x, hitPt.y );
       bubbleEvent(e, hit, "onPreMouseMove", "onMouseMove");
 #endif
 #endif
@@ -1791,7 +1780,6 @@ void pxScene2d::onKeyDown(uint32_t keyCode, uint32_t flags)
     e.set("keyCode", keyCode);
     e.set("flags", (uint32_t)flags);
     rtRefT<pxObject> t = (pxObject*)mFocusObj.get<voidPtr>("_pxObject");
-    WAYLAND_EVENT( onKeyDown, t, keyCode, flags );
     bubbleEvent(e, t, "onPreKeyDown", "onKeyDown");
   }
 }
@@ -1805,7 +1793,6 @@ void pxScene2d::onKeyUp(uint32_t keyCode, uint32_t flags)
     e.set("keyCode", keyCode);
     e.set("flags", (uint32_t)flags);
     rtRefT<pxObject> t = (pxObject*)mFocusObj.get<voidPtr>("_pxObject");
-    WAYLAND_EVENT( onKeyUp, t, keyCode, flags );
     bubbleEvent(e, t, "onPreKeyUp", "onKeyUp");
   }
 }

--- a/examples/pxScene2d/src/pxScene2d.h
+++ b/examples/pxScene2d/src/pxScene2d.h
@@ -992,9 +992,9 @@ public:
   rtError createFontResource(rtObjectRef p, rtObjectRef& o);  
   rtError createScene(rtObjectRef p,rtObjectRef& o);
   rtError createExternal(rtObjectRef p, rtObjectRef& o);
+  rtError createWayland(rtObjectRef p, rtObjectRef& o);
 
   rtError clock(uint64_t & time);
-  rtError createWayland(rtObjectRef p, rtObjectRef& o);
 
   rtError addListener(rtString eventName, const rtFunctionRef& f)
   {
@@ -1129,7 +1129,7 @@ private:
   bool mShowDirtyRect;
   #ifdef USE_SCENE_POINTER
   pxTextureRef mNullTexture;
-  pxTextureCacheObject mPointerTextureCacheObj;
+  rtObjectRef mPointerResource;
   pxTextureRef mPointerTexture;
   int32_t mPointerX;
   int32_t mPointerY;

--- a/examples/pxScene2d/src/pxWayland.h
+++ b/examples/pxScene2d/src/pxWayland.h
@@ -5,101 +5,131 @@
 #define PX_WAYLAND_H
 
 #include <pthread.h>
+#include "pxIView.h"
+#include "pxScene2d.h"
 #include "pxContext.h"
 #include "rtMutex.h"
 #include "pxTexture.h"
+#include "rtObject.h"
 #ifdef ENABLE_PX_WAYLAND_RPC
 #include "rtRpc.h"
 #endif //ENABLE_PX_WAYLAND_RPC
 
 #include "westeros-compositor.h"
 
-class pxWayland: public pxObject {
+class pxWaylandEvents {
 public:
-  rtDeclareObject(pxWayland, pxObject);
-  rtProperty(displayName, displayName, setDisplayName, rtString);
-  rtProperty(cmd, cmd, setCmd, rtString);
-  rtReadOnlyProperty(clientPID, clientPID, int32_t);
-  rtProperty(fillColor, fillColor, setFillColor, uint32_t);
-  rtProperty(hasApi, hasApi, setHasApi, bool);
-  rtReadOnlyProperty(api, api, rtValue);
-  
-  pxWayland(pxScene2d* scene);
+  pxWaylandEvents() {}
+  virtual ~pxWaylandEvents() {}
 
+  virtual void invalidate( pxRect* /*r*/ ) {}
+  virtual void hidePointer( bool /*hide*/ ) {}
+  virtual void clientStarted( int /*pid*/ ) {}  
+  virtual void clientConnected( int /*pid*/ ) {}
+  virtual void clientDisconnected( int /*pid*/ ) {}
+  virtual void clientStoppedNormal( int /*pid*/, int /*exitCode*/ ) {}
+  virtual void clientStoppedAbnormal( int /*pid*/, int /*signo*/ ) {}
+  virtual void isReady( bool /*ready*/ ) {}
+};
+
+class pxWayland: public pxIView {
+
+public:
+  pxWayland();
   virtual ~pxWayland();
 
-  virtual void onInit();
-  virtual void sendPromise();
+  virtual unsigned long AddRef() {
+    return rtAtomicInc(&mRefCount);
+  }
   
+  virtual unsigned long Release() {
+    long l = rtAtomicDec(&mRefCount);
+    if (l == 0) delete this;
+    return l;
+  }
+
+  virtual void setViewContainer(pxIViewContainer* l) 
+  {
+    mContainer = l;
+  }
+  
+  void setEvents( pxWaylandEvents *events )
+  {
+     mEvents= events;
+  }
+
   rtError displayName(rtString& s) const;
   rtError setDisplayName(const char* s);
 
-  rtError cmd(rtString& s) const { s = m_cmd; return RT_OK; }
+  rtError cmd(rtString& s) const { s = mCmd; return RT_OK; }
   rtError setCmd(const char* s)
   {
-     m_cmd = s;
+     mCmd= s;
      return RT_OK;
-  }
-
-  rtError fillColor(uint32_t& /*c*/) const 
-  {
-    rtLogWarn("fillColor not implemented");
-    return RT_OK;
   }
 
   rtError setFillColor(uint32_t c) 
   {
-    m_fillColor[0] = (float)((c>>24)&0xff)/255.0f;
-    m_fillColor[1] = (float)((c>>16)&0xff)/255.0f;
-    m_fillColor[2] = (float)((c>>8)&0xff)/255.0f;
-    m_fillColor[3] = (float)((c>>0)&0xff)/255.0f;
+    mFillColor[0] = (float)((c>>24)&0xff)/255.0f;
+    mFillColor[1] = (float)((c>>16)&0xff)/255.0f;
+    mFillColor[2] = (float)((c>>8)&0xff)/255.0f;
+    mFillColor[3] = (float)((c>>0)&0xff)/255.0f;
     return RT_OK;
   }
 
   rtError hasApi(bool& v) const
   {
-    v=m_hasApi;
+    v=mHasApi;
     return RT_OK;
   }
   rtError setHasApi(bool v)
   {
-    m_hasApi = v;
+    mHasApi = v;
     return RT_OK;
   }
-
+  
   rtError api(rtValue& v) const
   {
-    m_remoteObjectMutex.lock();
-    v = m_API;
-    m_remoteObjectMutex.unlock();
+    mRemoteObjectMutex.lock();
+    v = mAPI;
+    mRemoteObjectMutex.unlock();
     return RT_OK;
   }
 
-  rtError clientPID(int32_t& pid) const { pid = m_clientPID; return RT_OK; }
-  
-  void onKeyDown(uint32_t keycode, uint32_t flags);
-  void onKeyUp(uint32_t keycode, uint32_t flags);
-  void onMouseEnter();
-  void onMouseLeave();
-  void onMouseMove( float x, float y );
-  void onMouseDown();
-  void onMouseUp();
+  virtual void onInit();
+
+  virtual void onSize(int32_t w, int32_t h);
+  virtual void onMouseDown(int32_t x, int32_t y, uint32_t flags);
+  virtual void onMouseUp(int32_t x, int32_t y, uint32_t flags);
+  virtual void onMouseEnter();
+  virtual void onMouseLeave();
+  virtual void onMouseMove(int32_t x, int32_t y);
+  virtual void onFocus();
+  virtual void onBlur();
+  virtual void onKeyDown(uint32_t keycode, uint32_t flags);
+  virtual void onKeyUp(uint32_t keycode, uint32_t flags);
+  virtual void onChar(uint32_t codepoint);
+  virtual void onUpdate(double t);
+  virtual void onDraw();
 
 private:
-  pthread_t m_clientMonitorThreadId;
-  pthread_t m_findRemoteThreadId;
-  pthread_mutex_t m_mutex;
-  bool m_clientMonitorStarted;
-  bool m_waitingForRemoteObject;
-  
+  rtAtomic mRefCount;
+  pthread_t mClientMonitorThreadId;
+  pthread_t mFindRemoteThreadId;
+  pxIViewContainer *mContainer;
+  bool mReadyEmitted;
+  bool mClientMonitorStarted;
+  bool mWaitingForRemoteObject;
+  int mWidth;
+  int mHeight;
+
   static void invalidate( WstCompositor *wctx, void *userData );
   static void hidePointer( WstCompositor *wctx, bool hide, void *userData );
   static void clientStatus( WstCompositor *wctx, int status, int pid, int detail, void *userData );
-  void handleClientStarted( int pid );
-  void handleClientStoppedNormal( int pid, int exitCode );
-  void handleClientStoppedAbnormal( int pid, int signo );
-  void handleClientConnected( int pid );
-  void handleClientDisconnected( int pid );
+
+  void handleInvalidate();  
+  void handleHidePointer( bool hide );
+  void handleClientStatus( int status, int pid, int detail );
   void launchClient();
   void launchAndMonitorClient();
   void terminateClient();
@@ -110,25 +140,79 @@ private:
   void startRemoteObjectDetection();
   rtError connectToRemoteObject();
   rtError startRemoteObjectLocator();
-      
-protected:
-  virtual void draw();
-  void createDisplay(rtString displayName);
-  
-  rtString m_DisplayName;
-  rtString m_cmd;
-  int32_t m_clientPID;
-  pxContextFramebufferRef m_fbo;
-  WstCompositor *m_wctx;
-  float m_fillColor[4];
 
-  bool m_hasApi;
-  rtValue m_API;
+protected:
+  void createDisplay(rtString displayName);
+
+  rtString mDisplayName;
+  rtString mCmd;
+  pxWaylandEvents *mEvents;
+  int32_t mClientPID;
+  pxContextFramebufferRef mFBO;
+  WstCompositor *mWCtx;
+  float mFillColor[4];
+
+  bool mHasApi;
+  rtValue mAPI;
 #ifdef ENABLE_PX_WAYLAND_RPC
-  rtObjectRef m_remoteObject;
+  rtObjectRef mRemoteObject;
 #endif
-  rtString m_remoteObjectName;
-  mutable rtMutex m_remoteObjectMutex;
+  rtString mRemoteObjectName;
+  mutable rtMutex mRemoteObjectMutex;
 };
 
+class pxWaylandContainer: public pxViewContainer, pxWaylandEvents {
+  rtDeclareObject(pxWaylandContainer, pxViewContainer);
+  rtProperty(displayName, displayName, setDisplayName, rtString);
+  rtProperty(cmd, cmd, setCmd, rtString);
+  rtReadOnlyProperty(clientPID, clientPID, int32_t);
+  rtProperty(fillColor, fillColor, setFillColor, uint32_t);
+  rtProperty(hasApi, hasApi, setHasApi, bool);
+  rtReadOnlyProperty(api, api, rtValue);
+
+public:
+  pxWaylandContainer(pxScene2d* scene);
+
+  rtError setView(pxWayland* v);
+
+  virtual void onInit();
+
+  virtual void invalidate( pxRect* r );
+  virtual void hidePointer( bool hide );
+  virtual void clientStarted( int pid );
+  virtual void clientConnected( int pid );
+  virtual void clientDisconnected( int pid );
+  virtual void clientStoppedNormal( int pid, int exitCode );
+  virtual void clientStoppedAbnormal( int pid, int signo );
+  virtual void isReady( bool ready );
+
+  rtError displayName(rtString& s) const;
+  rtError setDisplayName(const char* s);
+
+  rtError cmd(rtString& s) const { s = mCmd; return RT_OK; }
+  rtError setCmd(const char* s);
+
+  rtError clientPID(int32_t& pid) const { pid = mClientPID; return RT_OK; }
+
+  rtError fillColor(uint32_t& c) const;
+  rtError setFillColor(uint32_t c);
+
+  rtError hasApi(bool& v) const;
+  rtError setHasApi(bool v);
+
+  rtError api(rtValue& v) const;
+
+private:
+  rtString mDisplayName;
+  rtString mCmd;
+  pxWayland *mWayland;
+  int32_t mClientPID;
+  uint32_t mFillColor;
+  bool mHasApi;
+  rtValue mAPI;  
+};
+
+typedef rtRefT<pxWayland> pxWaylandRef;
+
 #endif
+


### PR DESCRIPTION
pxWayland is now a pxIView and when pxScene2d creates an wayland instance it places it within a pxWaylandContainer.  All events and properties formerly accessible from pxWayland are now accessible from pxWaylandContainer.  The refactoring includes some variable name changes to better match the overall style of pxScene code.