### PR TITLE
Avoid setting TCP_NODELAY option to sockets with non-TCP types

### DIFF
--- a/examples/pxScene2d/src/rpc/rtSocketUtils.cpp
+++ b/examples/pxScene2d/src/rpc/rtSocketUtils.cpp
@@ -4,6 +4,8 @@
 #include <sstream>
 
 #include <netinet/in.h>
+#include <sys/socket.h>
+#include <netinet/tcp.h>
 #include <errno.h>
 #include <arpa/inet.h>
 #include <net/if.h>
@@ -442,6 +444,20 @@ rtGetPeerName(int fd, sockaddr_storage& endpoint)
   }
 
   memcpy(&endpoint, &addr, sizeof(sockaddr_storage));
+  return RT_OK;
+}
+
+rtError
+rtSocketSetNoDelay(int fd, int socket_type)
+{
+  if (socket_type == SOCK_STREAM)
+  {
+    uint32_t one = 1;
+    if (-1 == setsockopt(fd, SOL_TCP, TCP_NODELAY, &one, sizeof(one)))
+    {
+      return RT_FAIL;
+    }
+  }
   return RT_OK;
 }
 

--- a/examples/pxScene2d/src/rpc/rtSocketUtils.h
+++ b/examples/pxScene2d/src/rpc/rtSocketUtils.h
@@ -19,6 +19,7 @@ rtError rtReadUntil(int fd, char* buff, int n);
 rtError rtReadMessage(int fd, rtSocketBuffer& buff, rtJsonDocPtr& doc);
 rtError rtParseMessage(char const* buff, int n, rtJsonDocPtr& doc);
 std::string rtSocketToString(sockaddr_storage const& ss);
+rtError rtSocketSetNoDelay(int fd, int socket_type);
 
 // this really doesn't belong here, but putting it here for now
 rtError rtSendDocument(rapidjson::Document const& doc, int fd, sockaddr_storage const* dest);


### PR DESCRIPTION
also, refactoring: moving the tcp option setting to utils module