### PR TITLE
Fix hang on cleaning the cache with one item

### DIFF
--- a/examples/pxScene2d/src/rpc/rtObjectCache.cpp
+++ b/examples/pxScene2d/src/rpc/rtObjectCache.cpp
@@ -103,12 +103,9 @@ rtObjectCache::removeUnused()
   int const maxAge = rtRemoteSetting<int>("rt.rpc.cache.max_object_lifetime");
 
   std::unique_lock<std::mutex> lock(sMutex);
-  for (auto itr = sRefMap.begin(); itr != sRefMap.end(); ++itr)
+  for (auto itr = sRefMap.begin(); itr != sRefMap.end();)
   {
-    if (itr->second.MaxAge == -1)
-      continue;
-
-    if ((now - itr->second.LastUsed) > maxAge)
+    if (itr->second.MaxAge > -1 && (now - itr->second.LastUsed) > maxAge)
     {
       rtLogInfo("removing %s. It's last access time:%d is older max allowed: %d",
           itr->first.c_str(),
@@ -116,6 +113,8 @@ rtObjectCache::removeUnused()
           maxAge);
       itr = sRefMap.erase(itr);
     }
+    else
+        ++itr;
   }
 
   return RT_OK;

--- a/examples/pxScene2d/src/rpc/rtRemoteServer.cpp
+++ b/examples/pxScene2d/src/rpc/rtRemoteServer.cpp
@@ -563,7 +563,7 @@ rtRemoteServer::onMethodCall(std::shared_ptr<rtRemoteClient>& client, rtJsonDocP
       func = rtObjectCache::findFunction(function_name->value.GetString());
     }
 
-    if (err == RT_OK)
+    if (err == RT_OK && !!func)
     {
       // virtual rtError Send(int numArgs, const rtValue* args, rtValue* result) = 0;
       std::vector<rtValue> argv;


### PR DESCRIPTION
The iterator returned by std::map::erase already points to next element(or map::end), it shouldn't be incremented in for-loop's afterthought part.