### PR TITLE
Exclude westeros-stub impl when westeros_compositor is found in SYS_ROOT

### DIFF
--- a/examples/pxScene2d/src/Makefile
+++ b/examples/pxScene2d/src/Makefile
@@ -10,6 +10,7 @@ all: pxscene
 libs: librtCore.so libpxscene.so
 endif
 
+HAVE_SYSTEM_WESTEROS := $(shell pkg-config --exists westeros-compositor && echo 1)
 HAVE_WESTEROS := $(shell test -f ../external/westeros/Makefile.ubuntu && echo 1)
 
 clean:
@@ -66,9 +67,11 @@ RT_SRCS_FULL=\
     linux/rtMutexNative.cpp \
     linux/rtThreadPoolNative.cpp
 
+ifneq ($(HAVE_SYSTEM_WESTEROS),1)
 ifeq ($(HAVE_WESTEROS),1)
 else
 RT_SRCS_FULL += ../external/westeros-stub/westeros-stub.cpp
+endif
 endif
 
 PX_SRCS_FULL=\
@@ -155,8 +158,10 @@ LDWESTEROS = -L$(EXTDIR)/westeros/external/install/lib -lwesteros_compositor
 
 
 LDEXT   = $(LDPNG) $(LDJPG) $(LDFT) $(LDCURL) $(LDNODE) $(LDNODEV8) $(LDZLIB)
+ifneq ($(HAVE_SYSTEM_WESTEROS),1)
 ifeq ($(HAVE_WESTEROS),1)
 LDEXT += $(LDWESTEROS)
+endif
 endif
 ifeq ($(UNAME_S),Linux)
 LDEXT += -lX11
@@ -229,9 +234,11 @@ PXSCENE_LIB_SRCS += pxContextDFB.cpp
 endif
 
 
+ifneq ($(HAVE_SYSTEM_WESTEROS),1)
 ifeq ($(HAVE_WESTEROS),1)
 else
 PXSCENE_LIB_SRCS += ../external/westeros-stub/westeros-stub.cpp
+endif
 endif
 
 PXSCENE_LIB_OBJS =$(patsubst ../%.cpp, %.o        , $(notdir $(PXSCENE_LIB_SRCS)))


### PR DESCRIPTION
westeros-stub is always being built and have to preload system provided libwesteros_compositor.so