### PR TITLE
Increase number of retries for detecting rtRemote, as the retry inter…

### DIFF
--- a/examples/pxScene2d/src/pxWayland.cpp
+++ b/examples/pxScene2d/src/pxWayland.cpp
@@ -22,7 +22,7 @@ using namespace std;
 extern pxContext context;
 
 #define MAX_FIND_REMOTE_TIMEOUT_IN_MS 5000
-#define FIND_REMOTE_ATTEMPT_TIMEOUT_IN_MS 500
+#define FIND_REMOTE_ATTEMPT_TIMEOUT_IN_MS 100
 #define TEST_REMOTE_OBJECT_NAME "waylandClient123" //TODO - update
 
 #define UNUSED_PARAM(x) ((x)=(x))


### PR DESCRIPTION
…val is reduced from 3 seconds to 100 milliseconds.

Timeout value for retry for detecting rtRemote is reduced from 3 seconds to 100ms (This is to reduce the startup delay of connecting to rtRemote based wayland applications. Delay occurs when rtRemote server comes up after few ms after rtRemoteclient comes up , in which case first UDP message is lost and the second UDP message is sent after 3 seconds to rtRemoteServer). Due to this change in retry interval, number of retries for connecting to rt remote server is increased from 10 to 50. If the count is 10, remote client is retrying only for 1000 ms, so sometimes, server results being undetected.