### PR TITLE
Updates for making calling rtremote properties/methods from javascript

### DIFF
--- a/examples/pxScene2d/src/pxWayland.cpp
+++ b/examples/pxScene2d/src/pxWayland.cpp
@@ -1241,4 +1241,4 @@ rtDefineProperty(pxWaylandContainer,displayName);
 rtDefineProperty(pxWaylandContainer,cmd);
 rtDefineProperty(pxWaylandContainer,clientPID);
 rtDefineProperty(pxWaylandContainer,fillColor);
-
+rtDefineProperty(pxWaylandContainer,api);

--- a/examples/pxScene2d/src/rpc/rtRemoteClient.cpp
+++ b/examples/pxScene2d/src/rpc/rtRemoteClient.cpp
@@ -175,6 +175,12 @@ rtRemoteClient::sendGet(rtRemoteGetRequest const& req, rtValue& value, uint32_t 
     return RT_FAIL;
   }
 
+  rtError statusCode = rtMessage_GetStatusCode(*res);
+  if (statusCode != RT_OK)
+  {
+    return statusCode;
+  }
+
   auto itr = res->FindMember(kFieldNameValue);
   if (itr == res->MemberEnd())
   {

--- a/examples/pxScene2d/src/rpc/rtValueReader.cpp
+++ b/examples/pxScene2d/src/rpc/rtValueReader.cpp
@@ -36,7 +36,7 @@ rtValueReader::read(rtValue& to, rapidjson::Value const& from, std::shared_ptr<r
   }
 
   auto val = from.FindMember(kFieldNameValueValue);
-  if (type->value.GetInt() != RT_functionType && val == from.MemberEnd())
+  if ((type->value.GetInt() != RT_functionType) && (type->value.GetInt() != RT_voidType) && val == from.MemberEnd())
   {
     rtLogWarn("failed to find member: %s", kFieldNameValueValue);
     return RT_FAIL;


### PR DESCRIPTION
Kindly review. Changes are made to call rtremote properties/methods from javascript.

Example usage from javascript:
var wayland = <get pxwayland object>;
var remoteObj = wayland.api;
remoteObject.propertyX = "value";
remoteObj.funcX();
var propertyY = remoteObject.propertyY; 