### PR TITLE
Fix for a crash problem: terminateClient makes use of the context which is destroyed by the call to WstCompositorDestroy.

### DIFF
--- a/examples/pxScene2d/src/pxWayland.cpp
+++ b/examples/pxScene2d/src/pxWayland.cpp
@@ -60,8 +60,8 @@ pxWayland::~pxWayland()
 { 
   if ( mWCtx )
   {
-     WstCompositorDestroy(mWCtx);
      terminateClient();
+     WstCompositorDestroy(mWCtx);
   }
 }
 


### PR DESCRIPTION
Changing the call order seems to help to eliminate the crash. Please review.
