### PR TITLE
Fix for a crash problem: terminateClient makes use of the context which is destroyed by the call to WstCompositorDestroy.

### DIFF
--- a/examples/pxScene2d/src/pxWayland.cpp
+++ b/examples/pxScene2d/src/pxWayland.cpp
@@ -61,8 +61,8 @@ pxWayland::~pxWayland()
 { 
   if ( mWCtx )
   {
-     WstCompositorDestroy(mWCtx);
      terminateClient();
+     WstCompositorDestroy(mWCtx);
   }
 }
 


### PR DESCRIPTION
terminateClient makes use of the context which was destroyed by the call WstCompositorDestroy.
