### PR TITLE
Build fix and unwiring pxwayland from libnode/pxscene

### DIFF
--- a/examples/pxScene2d/src/Makefile
+++ b/examples/pxScene2d/src/Makefile
@@ -278,7 +278,7 @@ PXWAYLAND_LIB_SRCS=\
            pxContextGL.cpp
 
 ifneq ($(DISABLE_WAYLAND),TRUE)
-PXWAYLAND_LIB_SRCS:=pxWayland.cpp
+PXWAYLAND_LIB_SRCS += pxWayland.cpp
 endif
 
 PXWAYLAND_LIB_OBJS =$(patsubst ../%.cpp, %.o        , $(notdir $(PXWAYLAND_LIB_SRCS)))

--- a/examples/pxScene2d/src/rpc/rtRemoteMulticastResolver.cpp
+++ b/examples/pxScene2d/src/rpc/rtRemoteMulticastResolver.cpp
@@ -103,7 +103,7 @@ rtError rtRemoteMulticastResolver::sendSearchAndWait(const std::string& name, co
     if (err != RT_OK)
       return err;
 
-    rtLogInfo("Spinning for %llu ms", milliseconds(iterationIncrement).count());
+    rtLogInfo("Spinning for %llu ms", static_cast<long long unsigned int>(milliseconds(iterationIncrement).count()));
 
     m_cond.wait_until(lock, iterationTime, [this, seqId, &searchResponse] {
       auto itr = this->m_pending_searches.find(seqId);


### PR DESCRIPTION
Two commits;
First one fixes typo which breaks the build in runtime
Second unwires pxWayland from libnode and pxscene