### PR TITLE
Improved visual quality for scaled text and bugs

### DIFF
--- a/examples/pxScene2d/src/pxFont.cpp
+++ b/examples/pxScene2d/src/pxFont.cpp
@@ -305,6 +305,8 @@ const GlyphCacheEntry* pxFont::getGlyph(uint32_t codePoint)
       entry->advancedoty = g->advance.y;
       entry->vertAdvance = g->metrics.vertAdvance; // !CLF: Why vertAdvance? SHould only be valid for vert layout of text.
 
+      gGlyphCache.insert(make_pair(key,entry));
+
       return entry;
     }
   }

--- a/examples/pxScene2d/src/pxFont.cpp
+++ b/examples/pxScene2d/src/pxFont.cpp
@@ -50,8 +50,10 @@ struct GlyphKey
 };
 
 typedef map<GlyphKey,GlyphCacheEntry*> GlyphCache;
+typedef map<GlyphKey,pxTextureRef> GlyphTextureCache;
 
 GlyphCache gGlyphCache;
+GlyphTextureCache gGlyphTextureCache;
 
 #include "pxContext.h"
 
@@ -67,11 +69,19 @@ extern "C" {
 FT_Library ft;
 uint32_t gFontId = 0;
 
+// TODO move out to rt* utility
+uint32_t npot(uint32_t i)
+{
+  uint32_t power = 1;
+  while(power < i)
+    power*=2;
+  return power;
+}
+
 pxFont::pxFont(rtString fontUrl):pxResource(),mPixelSize(0), mFontData(0)
 {  
   mFontId = gFontId++; 
   mUrl = fontUrl;
-
 }
 
 pxFont::~pxFont() 
@@ -99,6 +109,7 @@ pxFont::~pxFont()
   } 
    
 }
+
 bool pxFont::loadResourceData(rtFileDownloadRequest* fileDownloadRequest)
 {
       // Load the font data
@@ -211,6 +222,60 @@ void pxFont::getMetrics(uint32_t size, float& height, float& ascender, float& de
   naturalLeading = height - (ascender + descender);
 
 }
+
+pxTextureRef pxFont::getGlyphTexture(uint32_t codePoint, float sx, float sy)
+{
+  // Select a glyph texture better suited for rendering the glyph
+  // taking pixelSize and scale into account
+  uint32_t pixelSize=(uint32_t)ceil((sx>sy?sx:sy)*mPixelSize);
+  if (pixelSize <= 48)
+    pixelSize = (pixelSize + 7) & 0xfffffff8;    // next multiple of 8
+  else
+    pixelSize = npot(pixelSize);  // else next power of two
+ 
+  GlyphKey key; 
+  key.mFontId = mFontId; 
+  key.mPixelSize = pixelSize; 
+  key.mCodePoint = codePoint;
+  GlyphTextureCache::iterator it = gGlyphTextureCache.find(key);
+  if (it != gGlyphTextureCache.end())
+    return it->second;
+  else
+  {
+    // temporarily set pixel size to more optimal size for
+    // rendering texture 
+    FT_Set_Pixel_Sizes(mFace, 0, pixelSize);
+    // TODO only need to render glyph here
+    if(!FT_Load_Char(mFace, codePoint, FT_LOAD_RENDER))
+    {
+      rtLogDebug("glyph texture cache miss");
+
+      GlyphCacheEntry *entry = new GlyphCacheEntry;
+      FT_GlyphSlot g = mFace->glyph;
+      
+      entry->bitmap_left = g->bitmap_left;
+      entry->bitmap_top = g->bitmap_top;
+      entry->bitmapdotwidth = g->bitmap.width;
+      entry->bitmapdotrows = g->bitmap.rows;
+      entry->advancedotx = g->advance.x;
+      entry->advancedoty = g->advance.y;
+      entry->vertAdvance = g->metrics.vertAdvance; // !CLF: Why vertAdvance? SHould only be valid for vert layout of text.
+
+      pxTextureRef texture = context.createTexture(g->bitmap.width, g->bitmap.rows, 
+                                              g->bitmap.width, g->bitmap.rows, 
+                                              g->bitmap.buffer);
+      
+      gGlyphTextureCache.insert(make_pair(key,texture));
+
+      // restore current pixelSize
+      FT_Set_Pixel_Sizes(mFace, 0, mPixelSize);
+      return texture;  
+    }
+    // restore current pixelSize
+    FT_Set_Pixel_Sizes(mFace, 0, mPixelSize);
+  }
+  return NULL;  
+}
   
 const GlyphCacheEntry* pxFont::getGlyph(uint32_t codePoint)
 {
@@ -223,6 +288,7 @@ const GlyphCacheEntry* pxFont::getGlyph(uint32_t codePoint)
     return it->second;
   else
   {
+    // TODO should not need to render here !
     if(FT_Load_Char(mFace, codePoint, FT_LOAD_RENDER))
       return NULL;
     else
@@ -238,12 +304,7 @@ const GlyphCacheEntry* pxFont::getGlyph(uint32_t codePoint)
       entry->advancedotx = g->advance.x;
       entry->advancedoty = g->advance.y;
       entry->vertAdvance = g->metrics.vertAdvance; // !CLF: Why vertAdvance? SHould only be valid for vert layout of text.
-      
-      entry->mTexture = context.createTexture(g->bitmap.width, g->bitmap.rows, 
-                                              g->bitmap.width, g->bitmap.rows, 
-                                              g->bitmap.buffer);
-      
-      gGlyphCache.insert(make_pair(key,entry));
+
       return entry;
     }
   }
@@ -253,6 +314,9 @@ const GlyphCacheEntry* pxFont::getGlyph(uint32_t codePoint)
 void pxFont::measureTextInternal(const char* text, uint32_t size,  float sx, float sy, 
                          float& w, float& h) 
 {
+  // TODO ignoring sx and sy now
+  sx = 1.0;
+  sy = 1.0;
   if( !mInitialized) 
   {
     rtLogWarn("measureText called TOO EARLY -- not initialized or font not loaded!\n");
@@ -295,7 +359,7 @@ void pxFont::measureTextInternal(const char* text, uint32_t size,  float sx, flo
 }
 
 void pxFont::renderText(const char *text, uint32_t size, float x, float y, 
-                        float sx, float sy, 
+                        float nsx, float nsy, 
                         float* color, float mw) 
 {
   if (!text || !mInitialized)
@@ -316,11 +380,11 @@ void pxFont::renderText(const char *text, uint32_t size, float x, float y,
     if (!entry) 
       continue;
 
-    float x2 = x + entry->bitmap_left * sx;
-//    float y2 = y - g->bitmap_top * sy;
-    float y2 = (y - entry->bitmap_top * sy) + (metrics->ascender>>6);
-    float w = entry->bitmapdotwidth * sx;
-    float h = entry->bitmapdotrows * sy;
+    float x2 = x + entry->bitmap_left;
+//    float y2 = y - g->bitmap_top;
+    float y2 = (y - entry->bitmap_top) + (metrics->ascender>>6);
+    float w = entry->bitmapdotwidth;
+    float h = entry->bitmapdotrows;
     
     if (codePoint != '\n')
     {
@@ -331,17 +395,18 @@ void pxFont::renderText(const char *text, uint32_t size, float x, float y,
                              y+(metrics->ascender>>6), c);
       }
       
-      pxTextureRef texture = entry->mTexture;
+      //pxTextureRef texture = entry->mTexture;
+      pxTextureRef texture = getGlyphTexture(codePoint, nsx, nsy);
       pxTextureRef nullImage;
       context.drawImage(x2,y2, w, h, texture, nullImage, false, color);
-      x += (entry->advancedotx >> 6) * sx;
+      x += (entry->advancedotx >> 6);
       // no change to y because we are not moving to next line yet
     }
     else
     {
       x = 0;
       // Use height to advance to next line
-      y += (metrics->height>>6) * sy;
+      y += (metrics->height>>6);
     }
   }
 }
@@ -349,6 +414,9 @@ void pxFont::renderText(const char *text, uint32_t size, float x, float y,
 void pxFont::measureTextChar(u_int32_t codePoint, uint32_t size,  float sx, float sy, 
                          float& w, float& h) 
 {
+  // TODO ignoring sx and sy now
+  sx = 1.0;
+  sy = 1.0;
   if( !mInitialized) {
     rtLogWarn("measureTextChar called TOO EARLY -- not initialized or font not loaded!\n");
     return;
@@ -494,12 +562,8 @@ void pxFontManager::removeFont(rtString fontName)
 
 void pxFontManager::clearAllFonts()
 {
-  for (GlyphCache::iterator it =  gGlyphCache.begin(); it != gGlyphCache.end(); it++)
-  {
-    it->second->mTexture = NULL;
-    delete it->second;
-  }
   gGlyphCache.clear();
+  gGlyphTextureCache.clear();
 }
 
 // pxTextMetrics

--- a/examples/pxScene2d/src/pxFont.cpp
+++ b/examples/pxScene2d/src/pxFont.cpp
@@ -564,6 +564,9 @@ void pxFontManager::removeFont(rtString fontName)
 
 void pxFontManager::clearAllFonts()
 {
+  for (GlyphCache::iterator it =  gGlyphCache.begin(); it != gGlyphCache.end(); it++)
+    delete it->second;
+
   gGlyphCache.clear();
   gGlyphTextureCache.clear();
 }

--- a/examples/pxScene2d/src/pxFont.cpp
+++ b/examples/pxScene2d/src/pxFont.cpp
@@ -250,17 +250,8 @@ pxTextureRef pxFont::getGlyphTexture(uint32_t codePoint, float sx, float sy)
     {
       rtLogDebug("glyph texture cache miss");
 
-      GlyphCacheEntry *entry = new GlyphCacheEntry;
       FT_GlyphSlot g = mFace->glyph;
       
-      entry->bitmap_left = g->bitmap_left;
-      entry->bitmap_top = g->bitmap_top;
-      entry->bitmapdotwidth = g->bitmap.width;
-      entry->bitmapdotrows = g->bitmap.rows;
-      entry->advancedotx = g->advance.x;
-      entry->advancedoty = g->advance.y;
-      entry->vertAdvance = g->metrics.vertAdvance; // !CLF: Why vertAdvance? SHould only be valid for vert layout of text.
-
       pxTextureRef texture = context.createTexture(g->bitmap.width, g->bitmap.rows, 
                                               g->bitmap.width, g->bitmap.rows, 
                                               g->bitmap.buffer);

--- a/examples/pxScene2d/src/pxFont.h
+++ b/examples/pxScene2d/src/pxFont.h
@@ -37,7 +37,6 @@ class pxFont;
 #define defaultPixelSize 16
 #define defaultFont "FreeSans.ttf"
 
-
 class rtFileDownloadRequest;
 
 struct GlyphCacheEntry
@@ -49,8 +48,6 @@ struct GlyphCacheEntry
   int advancedotx;
   int advancedoty;
   int vertAdvance;
-
-  pxTextureRef mTexture;
 };
 
 
@@ -60,10 +57,11 @@ struct GlyphCacheEntry
  * pxTextMetrics
  * 
  **********************************************************************/
-class pxTextMetrics: public rtObject {
+class pxTextMetrics: public rtObject 
+{
 
 public:
-	pxTextMetrics(){  }
+	pxTextMetrics() {}
 	virtual ~pxTextMetrics() {}
 
 	rtDeclareObject(pxTextMetrics, rtObject);
@@ -106,12 +104,10 @@ public:
  * pxTextMeasurements
  * 
  **********************************************************************/
-class pxTextSimpleMeasurements: public rtObject {
-
+class pxTextSimpleMeasurements: public rtObject 
+{
 public:
-	pxTextSimpleMeasurements() { 
-
-  }
+	pxTextSimpleMeasurements() {}
 	virtual ~pxTextSimpleMeasurements() {}
 
 	rtDeclareObject(pxTextSimpleMeasurements, rtObject);
@@ -127,8 +123,6 @@ public:
   void setH(int32_t v) { mh = v; }  
     
 protected:
- 
-  
   int32_t mw;
   int32_t mh;
 };
@@ -154,7 +148,8 @@ public:
     
   // FT Face related functions
   void setPixelSize(uint32_t s);  
-  const GlyphCacheEntry* getGlyph(uint32_t codePoint);  
+  const GlyphCacheEntry* getGlyph(uint32_t codePoint);
+  pxTextureRef getGlyphTexture(uint32_t codePoint, float sx, float sy);  
   void getMetrics(uint32_t size, float& height, float& ascender, float& descender, float& naturalLeading);
   void getHeight(uint32_t size, float& height);
   void measureText(const char* text, uint32_t size, float& w, float& h);

--- a/examples/pxScene2d/src/pxText.cpp
+++ b/examples/pxScene2d/src/pxText.cpp
@@ -173,6 +173,9 @@ void pxText::draw() {
     // TODO not very intelligent given scaling
     if (msx == 1.0 && msy == 1.0 && mCached.getPtr() && mCached->getTexture().getPtr())
     {
+      // TODO review the max texure size handling
+      // Should be pushed into context properly  not 1 off on every
+      // callsite
       context.drawImage(0, 0, (mw>MAX_TEXTURE_WIDTH?MAX_TEXTURE_WIDTH:mw), (mh>MAX_TEXTURE_HEIGHT?MAX_TEXTURE_HEIGHT:mh), mCached->getTexture(), nullMaskRef);
     }
     else
@@ -217,11 +220,13 @@ rtError pxText::setFont(rtObjectRef o)
 
 float pxText::getOnscreenWidth()
 {
-  return (mw > MAX_TEXTURE_WIDTH?MAX_TEXTURE_WIDTH*msx:mw*msx);
+  // TODO review max texture handling
+  return (mw > MAX_TEXTURE_WIDTH?MAX_TEXTURE_WIDTH:mw);
 }
 float pxText::getOnscreenHeight()
 {
-  return (mh > MAX_TEXTURE_HEIGHT?MAX_TEXTURE_HEIGHT*msy:mh*msy);
+  // TODO review max texture handling
+  return (mh > MAX_TEXTURE_HEIGHT?MAX_TEXTURE_HEIGHT:mh);
 }
   
 

--- a/examples/pxScene2d/src/pxTextBox.cpp
+++ b/examples/pxScene2d/src/pxTextBox.cpp
@@ -1070,13 +1070,14 @@ void pxTextBox::renderTextRowWithTruncation(rtString & accString, float lineWidt
   }
 
 
+  // TODO this looks pretty inefficient... We should revisit... 
   for(int i = length; i > 0; i--)
   {
     tempStr[i] = '\0';
     charW = 0;
     charH = 0;
     getFontResource()->measureTextInternal(tempStr, pixelSize, sx, sy, charW, charH);
-    if( (tempX + charW + ellipsisW) <= lineWidth)
+    if ( (tempX + charW + ellipsisW) <= lineWidth)
     {
       float xPos = tempX;
       if( mTruncation == pxConstantsTruncation::TRUNCATE)

--- a/examples/pxScene2d/src/pxTextBox.cpp
+++ b/examples/pxScene2d/src/pxTextBox.cpp
@@ -200,7 +200,8 @@ rtError pxTextBox::setFont(rtObjectRef o)
 }
 
 
-void pxTextBox::draw() {
+void pxTextBox::draw() 
+{
   static pxTextureRef nullMaskRef;
   if (mCached.getPtr() && mCached->getTexture().getPtr())
   {
@@ -215,7 +216,7 @@ void pxTextBox::draw() {
     }
   }
   else
-    {
+  {
     renderText(true);
   }
 
@@ -243,10 +244,7 @@ void pxTextBox::update(double t)
  *  wrapping, truncation and dimensions; but it should not render the
  *  text yet.
  * */
-void pxTextBox::determineMeasurementBounds()
-{
-
-}
+void pxTextBox::determineMeasurementBounds() {}
 void pxTextBox::clearMeasurements()
 {
     lastLineNumber = 0;
@@ -264,7 +262,8 @@ void pxTextBox::renderText(bool render)
 {
   //rtLogDebug("pxTextBox::renderText render=%d initialized=%d fontLoaded=%d\n",render,mInitialized,mFontLoaded);
 
-  if( !mInitialized || !mFontLoaded) {
+  if( !mInitialized || !mFontLoaded) 
+  {
     return;
   }
 
@@ -297,6 +296,9 @@ void pxTextBox::renderText(bool render)
 
 void pxTextBox::renderTextWithWordWrap(const char *text, float sx, float sy, float tempX, uint32_t size, float* color, bool render)
 {
+  // TODO ignoring sx and sy now
+  sx = 1.0;
+  sy = 1.0;
   float tempY = 0;
 
   if( mAlignHorizontal == pxConstantsAlignHorizontal::LEFT && mTruncation != pxConstantsTruncation::NONE )
@@ -307,16 +309,16 @@ void pxTextBox::renderTextWithWordWrap(const char *text, float sx, float sy, flo
       // need to wrap to a new line
     }
   }
-
-
    measureTextWithWrapOrNewLine( text, sx, sy, tempX, tempY, size, color, render);
-
 }
 
 
 void pxTextBox::measureTextWithWrapOrNewLine(const char *text, float sx, float sy, float tempX, float &tempY,
                                            uint32_t size, float* color, bool render)
 {
+    // TODO ignoring sx and sy now
+    sx = 1.0;
+    sy = 1.0;
     //rtLogDebug(">>>>>>>>>>>>>>>>>>>> pxTextBox::measureTextWithWrapOrNewLine\n");
 
     u_int32_t charToMeasure;
@@ -326,12 +328,13 @@ void pxTextBox::measureTextWithWrapOrNewLine(const char *text, float sx, float s
     bool lastLine = false;
     float lineWidth = mw;
 
-
     // If really rendering, startY should reflect value for any verticalAlignment adjustments
-    if( render) {
+    if( render) 
+    {
       tempY = startY;
     }
-    if(lineNumber == 0) {
+    if(lineNumber == 0) 
+    {
       if( mAlignHorizontal == pxConstantsAlignHorizontal::LEFT)
       {
    //     setLineMeasurements(true, mXStartPos, tempY);
@@ -626,6 +629,10 @@ void pxTextBox::measureTextWithWrapOrNewLine(const char *text, float sx, float s
 
 void pxTextBox::renderOneLine(const char * tempStr, float tempX, float tempY, float sx, float sy, uint32_t size, float* color, float lineWidth, bool render )
 {
+  // TODO ignoring sx and sy now.
+  sx = 1.0;
+  sy = 1.0;
+
   float charW =0, charH=0;
 
   //rtLogDebug("pxTextBox::renderOneLine tempY=%f noClipY=%f tempStr=%s\n",tempY,noClipY, tempStr);
@@ -949,6 +956,9 @@ void pxTextBox::setLineMeasurements(bool firstLine, float xPos, float yPos)
  * */
 void pxTextBox::renderTextNoWordWrap(float sx, float sy, float tempX, bool render)
 {
+  //TODO ignoring sx and sy now
+  sx = 1.0;
+  sy = 1.0;
   //rtLogDebug("pxTextBox::renderTextNoWordWrap render=%d\n",render);
 
   float charW=0, charH=0;
@@ -1031,6 +1041,9 @@ void pxTextBox::renderTextRowWithTruncation(rtString & accString, float lineWidt
   //rtLogDebug(">>>>>>>>>>>>>>>>>>pxTextBox::renderTextRowWithTruncation lineNumber = %d render = %d\n",lineNumber, render);
   //rtLogDebug(">>>>>>>>>>>>>>>>>>pxTextBox::renderTextRowWithTruncation tempY = %f tempX = %f\n",tempY, tempX);
   //rtLogDebug(">>>>>>>>>>>>>>>>>>pxTextBox::renderTextRowWithTruncation lineWidth = %f \n",lineWidth);
+  // TODO ignoring sx and sy now
+  sx = 1.0;
+  sy = 1.0;
 
   float charW=0, charH=0;
   char * tempStr = strdup(accString.cString()); // Should give a copy


### PR DESCRIPTION
See textscale.js example.
- Separated glyph texture caching from glyph metric caching.
- Glyph textures are no longer one for one with a glyph's pixelSize.  A given pixelSize glyph may use the texture from a larger pixelSize glyph.  This reduces overall memory and provides more pixel data for sampling.
- Glyph rendering is done using the exact metrics for the specific pixelSize as reported by free type.  The selected glyph texture (which may be for a larger pixelSize) is scaled (down) to fit inside the glyph bounding box for the specificed pixelSize.
- Glyph texture selection now takes into account the necessary LOD (Level of Detail) needed based on sx and sy scale factors.  Greatly improving visual quality when scaling text.