### PR TITLE
Making FPS box inactive. Transparent to click events etc.

### DIFF
--- a/examples/pxScene2d/src/browser.js
+++ b/examples/pxScene2d/src/browser.js
@@ -70,6 +70,10 @@ function reload(u) {
   else
     url.text = u;
 
+  // Remove Leading/Trailing whitespace...
+  u.trim();
+  url.text.trim();
+  
   console.log("RELOADING.... [ " + u + " ]");
 
   if (u.indexOf("local:") == 0) // LOCAL shorthand

--- a/examples/pxScene2d/src/shell.js
+++ b/examples/pxScene2d/src/shell.js
@@ -27,6 +27,10 @@ px.import({ scene: 'px:scene.1.js',
   fpsBg.w = fpsCounter.w+16;
   fpsBg.h = fpsCounter.h;
 
+  // Prevent interaction with scenes...
+  fpsBg.interactive = false;
+  fpsCounter.interactive = false;
+
   function updateSize(w, h) {
     childScene.w = w;
     childScene.h = h;


### PR DESCRIPTION
FPS box - when invisible was eating click events to edit box in **browser.js** .  Making FPS inactive fixes.