### PR TITLE
developer tool changes (debug log test)

### DIFF
--- a/examples/pxScene2d/src/pxScene.cpp
+++ b/examples/pxScene2d/src/pxScene.cpp
@@ -67,7 +67,8 @@ extern int g_argc;
 extern char** g_argv;
 char *nodeInput = NULL;
 #endif
-
+bool gDumpMemUsage = false;
+extern int pxObjectCount;
 class sceneWindow : public pxWindow, public pxIViewContainer
 {
 public:
@@ -280,6 +281,11 @@ int pxMain(int argc, char* argv[])
   uv_async_init(nodeLoop, &gcTrigger,garbageCollect);
 
 #endif
+char const* s = getenv("PX_DUMP_MEMUSAGE");
+if (s && (strcmp(s,"1") == 0))
+{
+  gDumpMemUsage = true;
+}
 #ifdef ENABLE_DEBUG_MODE
   int urlIndex  = -1;
   bool isDebugging = false;
@@ -368,6 +374,11 @@ int pxMain(int argc, char* argv[])
   context.init();
 
   eventLoop.run();
-
+  if (gDumpMemUsage)
+  {
+    script.garbageCollect();
+    rtLogInfo("pxobjectcount is [%d]",pxObjectCount);
+    rtLogInfo("texture memory usage is [%ld]",context.currentTextureMemoryUsageInBytes());
+  }
   return 0;
 }

--- a/examples/pxScene2d/src/pxScene2d.cpp
+++ b/examples/pxScene2d/src/pxScene2d.cpp
@@ -110,7 +110,7 @@ void stopProfiling()
   CALLGRIND_STOP_INSTRUMENTATION;
 }
 #endif //ENABLE_VALGRIND
-
+int pxObjectCount = 0;
 static char encoding_table[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
                                 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
                                 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
@@ -272,6 +272,44 @@ private:
 
 
 // pxObject methods
+pxObject::pxObject(pxScene2d* scene): rtObject(), mParent(NULL), mcx(0), mcy(0), mx(0), my(0), ma(1.0), mr(0),
+#ifdef ANIMATION_ROTATE_XYZ
+    mrx(0), mry(0), mrz(1.0),
+#endif //ANIMATION_ROTATE_XYZ
+    msx(1), msy(1), mw(0), mh(0),
+    mInteractive(true),
+    mSnapshotRef(), mPainting(true), mClip(false), mMask(false), mDraw(true), mHitTest(true), mReady(),
+    mFocus(false),mClipSnapshotRef(),mCancelInSet(true),mUseMatrix(false), mRepaint(true)
+#ifdef PX_DIRTY_RECTANGLES
+    , mIsDirty(false), mLastRenderMatrix(), mScreenCoordinates()
+#endif //PX_DIRTY_RECTANGLES
+    ,mDrawableSnapshotForMask(), mMaskSnapshot()
+  {
+    pxObjectCount++;
+    mScene = scene;
+    mReady = new rtPromise;
+    mEmit = new rtEmit;
+  }
+
+pxObject::~pxObject()
+{
+//    rtString d;
+    // TODO... why is this bad
+//    sendReturns<rtString>("description",d);
+    //rtLogDebug("**************** pxObject destroyed: %s\n",getMap()->className);
+    pxObjectCount--;
+    rtValue nullValue;
+    mReady.send("reject",nullValue);
+    deleteSnapshot(mSnapshotRef);
+    deleteSnapshot(mClipSnapshotRef);
+    deleteSnapshot(mDrawableSnapshotForMask);
+    deleteSnapshot(mMaskSnapshot);
+    mSnapshotRef = NULL;
+    mClipSnapshotRef = NULL;
+    mDrawableSnapshotForMask = NULL;
+    mMaskSnapshot = NULL;
+}
+
 void pxObject::sendPromise()
 {
   if(mInitialized && !((rtPromise*)mReady.getPtr())->status())
@@ -1453,6 +1491,15 @@ rtError pxScene2d::createScene(rtObjectRef p, rtObjectRef& o)
   return RT_OK;
 }
 
+rtError pxScene2d::logDebugMetrics()
+{
+  script.garbageCollect();
+  rtLogInfo("pxobjectcount is [%d]",pxObjectCount);
+  rtLogInfo("texture memory usage is [%ld]",context.currentTextureMemoryUsageInBytes());
+  return RT_OK;
+}
+
+
 rtError pxScene2d::clock(uint64_t & time)
 {
   time = (uint64_t)pxMilliseconds();
@@ -2292,6 +2339,7 @@ rtDefineProperty(pxScene2d, showOutlines);
 rtDefineProperty(pxScene2d, showDirtyRect);
 rtDefineMethod(pxScene2d, create);
 rtDefineMethod(pxScene2d, clock);
+rtDefineMethod(pxScene2d, logDebugMetrics);
 //rtDefineMethod(pxScene2d, createWayland);
 rtDefineMethod(pxScene2d, addListener);
 rtDefineMethod(pxScene2d, delListener);

--- a/examples/pxScene2d/src/pxScene2d.h
+++ b/examples/pxScene2d/src/pxScene2d.h
@@ -93,8 +93,6 @@ extern rtThreadQueue gUIThreadQueue;
 static pxConstants CONSTANTS;
 
 
-static int pxObjectCount = 0;
-
 #if 0
 typedef rtError (*objectFactory)(void* context, const char* t, rtObjectRef& o);
 void registerObjectFactory(objectFactory f, void* context);
@@ -209,25 +207,7 @@ public:
   rtProperty(m44,m44,setM44,float);
   rtProperty(useMatrix,useMatrix,setUseMatrix,bool);
 
-pxObject(pxScene2d* scene): rtObject(), mParent(NULL), mcx(0), mcy(0), mx(0), my(0), ma(1.0), mr(0),
-#ifdef ANIMATION_ROTATE_XYZ  
-    mrx(0), mry(0), mrz(1.0), 
-#endif //ANIMATION_ROTATE_XYZ
-    msx(1), msy(1), mw(0), mh(0),
-    mInteractive(true),
-    mSnapshotRef(), mPainting(true), mClip(false), mMask(false), mDraw(true), mHitTest(true), mReady(), 
-    mFocus(false),mClipSnapshotRef(),mCancelInSet(true),mUseMatrix(false), mRepaint(true)
-#ifdef PX_DIRTY_RECTANGLES
-    , mIsDirty(false), mLastRenderMatrix(), mScreenCoordinates()
-#endif //PX_DIRTY_RECTANGLES
-    ,mDrawableSnapshotForMask(), mMaskSnapshot()
-  {
-    pxObjectCount++;
-    mScene = scene;
-    mReady = new rtPromise;
-    mEmit = new rtEmit;
-  }
-
+  pxObject(pxScene2d* scene);
   virtual unsigned long Release()
   {
     rtString d;
@@ -242,24 +222,7 @@ pxObject(pxScene2d* scene): rtObject(), mParent(NULL), mcx(0), mcy(0), mx(0), my
     return c;
   }
 
-  virtual ~pxObject() 
-  { 
-//    rtString d;
-    // TODO... why is this bad
-//    sendReturns<rtString>("description",d);
-//    rtLogDebug("**************** pxObject destroyed: %s\n",getMap()->className); 
-    pxObjectCount--;
-    rtValue nullValue; 
-    mReady.send("reject",nullValue); 
-    deleteSnapshot(mSnapshotRef); 
-    deleteSnapshot(mClipSnapshotRef);
-    deleteSnapshot(mDrawableSnapshotForMask);
-    deleteSnapshot(mMaskSnapshot);
-    mSnapshotRef = NULL;
-    mClipSnapshotRef = NULL;
-    mDrawableSnapshotForMask = NULL;
-    mMaskSnapshot = NULL;
-  }
+  virtual ~pxObject() ;
 
   
 
@@ -1276,6 +1239,7 @@ public:
   rtMethod1ArgAndReturn("loadArchive",loadArchive,rtString,rtObjectRef); 
   rtMethod1ArgAndReturn("create", create, rtObjectRef, rtObjectRef);
   rtMethodNoArgAndReturn("clock", clock, uint64_t);
+  rtMethodNoArgAndNoReturn("logDebugMetrics", logDebugMetrics);
 /*
   rtMethod1ArgAndReturn("createExternal", createExternal, rtObjectRef,
                         rtObjectRef);
@@ -1366,6 +1330,7 @@ public:
   rtError createWayland(rtObjectRef p, rtObjectRef& o);
 
   rtError clock(uint64_t & time);
+  rtError logDebugMetrics();
 
   rtError addListener(rtString eventName, const rtFunctionRef& f)
   {

--- a/examples/pxScene2d/src/rcvrcore/scene.1.js
+++ b/examples/pxScene2d/src/rcvrcore/scene.1.js
@@ -36,6 +36,10 @@ function Scene() {
     return rpcContext;
   }
 
+  this.logDebugMetrics = function() {
+    return nativeScene.logDebugMetrics();
+  }
+
   this.loadArchive = function(u) {
     return nativeScene.loadArchive(u);
   }

--- a/examples/pxScene2d/src/shell.js
+++ b/examples/pxScene2d/src/shell.js
@@ -145,6 +145,11 @@ if (false)
         childScene.url = homeURL;
         e.stopPropagation();
       }
+      else
+      if(code == keys.D)  // ctrl-alt-shft-d
+      {
+	scene.logDebugMetrics();
+      }
     }// ctrl-alt-shift
   });
 

--- a/src/glut/pxWindowNative.cpp
+++ b/src/glut/pxWindowNative.cpp
@@ -725,6 +725,7 @@ static bool gTimerSet = false;
 void pxWindowNative::runEventLoop()
 {
 //glutSetOption(GLUT_ACTION_ON_WINDOW_CLOSE, GLUT_ACTION_GLUTMAINLOOP_RETURNS);
+  glutSetOption(GLUT_ACTION_ON_WINDOW_CLOSE, GLUT_ACTION_CONTINUE_EXECUTION);
 
   exitFlag = false;
 


### PR DESCRIPTION
1,Enabled changes for printing pxobject count and texture memory usage
2,ctrl+alt+shift+D is easter egg provided to print the details
3,Need to set PX_DUMP_MEMUSAGE=1 environment variable for getting pxobjects and current texture usage at end
4,Below are the debug statements to look for both 2 and 3:
pxobject count is
texture memory usage is