### PR TITLE
Don't do hole punching when drawing without FBO

### DIFF
--- a/examples/pxScene2d/src/pxWayland.cpp
+++ b/examples/pxScene2d/src/pxWayland.cpp
@@ -368,9 +368,9 @@ void pxWayland::onDraw()
      context.popState();
   }
   
-  if ( needHolePunch )
+  if ( drawWithFBO && needHolePunch )
   {
-     if ( drawWithFBO && (mFillColor[3] != 0.0) )
+     if ( mFillColor[3] != 0.0 )
      {
         context.drawImage(0, 0, mWidth, mHeight, mFBO->getTexture(), nullMaskRef);
      }


### PR DESCRIPTION
When rendering to default FBO the post rendering hole punching will clear everything, for example when there is a westerossink playing fullscreen.