### PR TITLE
Fix leaks due to module exports

### DIFF
--- a/examples/pxScene2d/src/rcvrcore/AppSceneContext.js
+++ b/examples/pxScene2d/src/rcvrcore/AppSceneContext.js
@@ -68,6 +68,12 @@ AppSceneContext.prototype.loadScene = function() {
 if( fullPath !== null)
   this.loadPackage(fullPath);
 
+  this.innerscene.on('onClose', function (e) {
+    if (this.innerscene.api != undefined)
+    {
+      for(var k in this.innerscene.api) { delete this.innerscene.api[k]; }
+    }
+  }.bind(this));
 if (false) {
 if (false) {
   // This no longer has access to the container


### PR DESCRIPTION
This address the case, where we have any js file that exports any objects to the container with,

module.exports.obj1
module.exports.obj2