### PR TITLE
fix for leaks fue to module exports and import of user-defined js file

### DIFF
--- a/examples/pxScene2d/src/rcvrcore/AppSceneContext.js
+++ b/examples/pxScene2d/src/rcvrcore/AppSceneContext.js
@@ -68,6 +68,41 @@ AppSceneContext.prototype.loadScene = function() {
 if( fullPath !== null)
   this.loadPackage(fullPath);
 
+this.innerscene.on('onClose', function (e) {
+
+    if (this.innerscene.api != undefined)
+    {
+      for(var k in this.innerscene.api) { delete this.innerscene.api[k]; }
+    }
+
+    this.innerscene.api = null;
+    this.innerscene = null;
+    this.sandbox.xmodule = null;
+    this.sandbox.require = null;
+    this.sandbox.sandboxName = null;
+    this.sandbox.runtime = null;
+    this.sandbox.theNamedContext = null;
+    this.sandbox.Buffer = null;
+    this.sandbox.setTimeout = null;
+    this.sandbox.setInterval = null;
+    this.sandbox.clearInterval = null;
+    this.sandbox.importTracking = {};
+    this.sandbox = null;
+    this.scriptMap = null;
+    for(var xmodule in this.xmoduleMap) {
+      this.xmoduleMap[xmodule].freeResources();
+    }
+    this.xmoduleMap = null;
+    this.topXModule = null;
+    this.jarFileMap = null;
+    for(var key in this.scriptMap) {
+      this.scriptMap[key].scriptObject = null;
+      this.scriptMap[key].readyListeners = null;
+    }
+    this.scriptMap = null;
+    this.sceneWrapper = null;
+  }.bind(this));
+
 if (false) {
 if (false) {
   // This no longer has access to the container


### PR DESCRIPTION
This address leaks due to below cases:

1, any js file that exports any objects to the container with,

module.exports.obj1
module.exports.obj2

2,any js file, which imports user-defined js file