### PR TITLE
introducing animation api returning animation object

### DIFF
--- a/examples/pxScene2d/src/Makefile
+++ b/examples/pxScene2d/src/Makefile
@@ -105,7 +105,8 @@ PX_SRCS_FULL=\
   pxImage.cpp \
   pxImage9.cpp \
   pxImageA.cpp \
-  pxArchive.cpp 
+  pxArchive.cpp \
+  pxAnimate.cpp
 
 EXTDIR=../external
 PXCOREDIR=../../..
@@ -262,7 +263,8 @@ PXSCENE_LIB_SRCS=\
   pxImage9.cpp \
   pxImageA.cpp \
   pxArchive.cpp \
-  pxFont.cpp 
+  pxFont.cpp \
+  pxAnimate.cpp
 
 ifneq ($(PX_PLATFORM),PX_PLATFORM_GENERIC_DFB)
 PXSCENE_LIB_SRCS += pxContextGL.cpp 

--- a/examples/pxScene2d/src/pxAnimate.cpp
+++ b/examples/pxScene2d/src/pxAnimate.cpp
@@ -1,0 +1,137 @@
+/*
+
+ pxCore Copyright 2005-2017 John Robinson
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+// pxAnimate.cpp
+
+#include "pxAnimate.h"
+#include "pxScene2d.h"
+
+pxAnimate::pxAnimate (rtObjectRef props, uint32_t interp, pxConstantsAnimation::animationOptions type, double duration, int32_t count, rtObjectRef promise, rtRef<pxObject> animateObj):mProps(props), mInterp(interp), mType(type), mProvisionedDuration(duration), mProvisionedCount(count), mCancelled(false), mStatus("IDLE"), mDonePromise(promise), mAnimatedObj(animateObj)
+{
+  mCurrDetails = new rtMapObject;
+  rtObjectRef keys = mProps.get<rtObjectRef>("allKeys");
+  if (keys)
+  {
+    uint32_t len = keys.get<uint32_t>("length");
+    for (uint32_t i = 0; i < len; i++)
+    {
+      rtObjectRef params = new pxAnimate::pxAnimationParams();
+      pxAnimate::pxAnimationParams* propParamsPtr = (pxAnimate::pxAnimationParams*) params.getPtr();
+      if (NULL != propParamsPtr)
+      {
+        rtString key = keys.get<rtString>(i);
+        propParamsPtr->mStatus = "IDLE";
+        propParamsPtr->mCancelled = false;
+        propParamsPtr->mCount = 0;
+        propParamsPtr->mFrom = 0;
+        propParamsPtr->mTo = 0;
+        propParamsPtr->mDuration = 0;
+        mCurrDetails.set(key,params);
+      }
+    }
+  }
+}
+
+pxAnimate::~pxAnimate()
+{
+}
+
+rtError pxAnimate::setCancel (bool cancel)
+{
+  // cancel all the properties of animation
+  if (cancel)
+  {
+    rtObjectRef keys = mProps.get<rtObjectRef>("allKeys");
+    if (keys)
+    {
+      uint32_t len = keys.get<uint32_t>("length");
+      for (uint32_t i = 0; i < len; i++)
+      {
+        rtString key = keys.get<rtString>(i);
+        mAnimatedObj.getPtr()->cancelAnimation(key, (mType & pxConstantsAnimation::OPTION_FASTFORWARD), (mType & pxConstantsAnimation::OPTION_REWIND), true);
+      }
+    }
+    mStatus = "CANCELLED";
+  }
+  mCancelled = cancel;
+  return RT_OK;
+}
+
+void pxAnimate::setStatus (uint32_t status)
+{
+  mStatus = mapStatus(status);
+}
+
+void pxAnimate::update (const char* prop, struct animation* params, uint32_t status)
+{
+  rtObjectRef propParams = mCurrDetails.get<rtObjectRef>(prop);
+  pxAnimate::pxAnimationParams* propParamsPtr = (pxAnimate::pxAnimationParams*) propParams.getPtr();
+
+  if (propParamsPtr != NULL)
+  {
+    propParamsPtr->mStatus = mapStatus(status);
+    propParamsPtr->mCount = params->actualCount;
+    propParamsPtr->mCancelled = params->cancelled;
+    propParamsPtr->mDuration = params->duration;
+    propParamsPtr->mFrom = params->from;
+    propParamsPtr->mTo = params->to;
+  }
+}
+
+rtString pxAnimate::mapStatus(uint32_t status)
+{
+   pxConstantsAnimation::animationStatus v = (pxConstantsAnimation::animationStatus) status;
+   if (v == pxConstantsAnimation::STATUS_IDLE)
+   {
+     return "IDLE";
+   }
+   else if ( v == pxConstantsAnimation::STATUS_INPROGRESS)
+   {
+     return "INPROGRESS";
+   }
+   else if ( v == pxConstantsAnimation::STATUS_CANCELLED)
+   {
+     return "CANCELLED";
+   }
+   else if ( v == pxConstantsAnimation::STATUS_ENDED)
+   {
+     return "ENDED";
+   }
+   return "UNKNOWN";
+}
+
+rtDefineObject(pxAnimate, rtObject);
+
+rtDefineProperty(pxAnimate, status);
+rtDefineProperty(pxAnimate, done);
+rtDefineProperty(pxAnimate, props);
+rtDefineProperty(pxAnimate, interp);
+rtDefineProperty(pxAnimate, type);
+rtDefineProperty(pxAnimate, provduration);
+rtDefineProperty(pxAnimate, provcount);
+rtDefineProperty(pxAnimate, cancel);
+rtDefineProperty(pxAnimate, details);
+
+rtDefineObject(pxAnimate::pxAnimationParams, rtObject);
+
+rtDefineProperty(pxAnimate::pxAnimationParams, status);
+rtDefineProperty(pxAnimate::pxAnimationParams, from);
+rtDefineProperty(pxAnimate::pxAnimationParams, to);
+rtDefineProperty(pxAnimate::pxAnimationParams, duration);
+rtDefineProperty(pxAnimate::pxAnimationParams, cancelled);
+rtDefineProperty(pxAnimate::pxAnimationParams, count);

--- a/examples/pxScene2d/src/pxAnimate.h
+++ b/examples/pxScene2d/src/pxAnimate.h
@@ -1,0 +1,116 @@
+/*
+
+ pxCore Copyright 2005-2017 John Robinson
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+*/
+
+// pxAnimate.h
+
+#ifndef PX_ANIMATE_H
+#define PX_ANIMATE_H
+
+#include "pxConstants.h"
+class pxObject;
+struct animation;
+/**********************************************************************
+ * 
+ * pxAnimate
+ * 
+ **********************************************************************/
+class pxAnimate: public rtObject
+{
+  public:
+
+    pxAnimate(rtObjectRef props, uint32_t interp, pxConstantsAnimation::animationOptions type, double duration, int32_t count, rtObjectRef promise, rtRef<pxObject> animateObj);
+
+    virtual ~pxAnimate();
+
+    rtDeclareObject(pxAnimate, rtObject);
+
+    // common properties of animation
+    rtReadOnlyProperty(done, done, rtObjectRef);
+    rtReadOnlyProperty(type, type, uint32_t);
+    rtReadOnlyProperty(interp, interp, uint32_t);
+    rtReadOnlyProperty(status, status, rtString);
+    rtReadOnlyProperty(provduration, provduration, double);
+    rtReadOnlyProperty(provcount, provcount, int32_t);
+    rtProperty(cancel, cancel, setCancel, bool);
+    rtReadOnlyProperty(props, props, rtObjectRef);
+    // property to describe the animation status of the properties mentioned in animate call
+    rtReadOnlyProperty(details, details, rtObjectRef);
+
+    rtError done(rtObjectRef& v)   const { v = mDonePromise; return RT_OK;   }
+    rtError type(uint32_t& v)   const { v = (uint32_t) mType; return RT_OK;   }
+    rtError interp(uint32_t& v)   const { v = mInterp; return RT_OK;   }
+    rtError status(rtString& v) const { v = mStatus; return RT_OK; };
+    rtError provduration(double& v)   const { v = mProvisionedDuration; return RT_OK;   }
+    rtError provcount(int32_t& v)   const { v = mProvisionedCount; return RT_OK;   }
+    rtError props(rtObjectRef& v)   const { v = mProps; return RT_OK;   }
+    rtError details(rtObjectRef& v) const { v = mCurrDetails; return RT_OK; }
+    rtError cancel(bool& v)   const { v = mCancelled; return RT_OK;   }
+
+    rtError setCancel(bool v);
+
+    // internal public methods
+    void setStatus(uint32_t v);
+    // update the animation details of every parameter
+    // this is invoked on every parameter update during the process of animation
+    void update(const char* prop, struct animation* params, uint32_t status);
+
+    class pxAnimationParams : public rtObject
+    {
+      public:
+        rtDeclareObject(pxAnimate::pxAnimationParams, rtObject);
+        rtReadOnlyProperty(from, from, double); 
+        rtReadOnlyProperty(to, to, double); 
+        rtReadOnlyProperty(duration, duration, double);
+        rtReadOnlyProperty(count, count, int32_t);
+        rtReadOnlyProperty(status, status, rtString);
+        rtReadOnlyProperty(cancelled, cancelled, bool);
+        
+        rtError from(double& v)   const { v = mFrom; return RT_OK;   }
+        rtError to(double& v)   const { v = (uint32_t) mTo; return RT_OK;   }
+        rtError duration(double& v)   const { v = mDuration; return RT_OK; }
+        rtError count(int32_t& v)   const { v = mCount; return RT_OK;   }
+        rtError status(rtString& v)   const { v = mStatus; return RT_OK;   }
+        rtError cancelled(bool& v)   const { v = mCancelled; return RT_OK;   }
+   
+        rtString mStatus;
+        int32_t mCount;
+        bool mCancelled;
+        double mDuration;
+        double mFrom;
+        double mTo;
+    };
+   
+  private:
+    rtString mapStatus(uint32_t v);
+
+    rtObjectRef mProps;
+    rtObjectRef mCurrDetails;
+    uint32_t mInterp;
+    pxConstantsAnimation::animationOptions mType;
+    double mProvisionedDuration;
+    int32_t mProvisionedCount;
+    bool mCancelled;
+    rtString mStatus;
+    rtObjectRef mDonePromise;
+    rtRef<pxObject> mAnimatedObj;
+};
+
+typedef rtRef<pxAnimate> pxAnimateRef;
+typedef rtRef<pxAnimate::pxAnimationParams> pxAnimateParamsRef;
+
+#endif

--- a/examples/pxScene2d/src/pxConstants.cpp
+++ b/examples/pxScene2d/src/pxConstants.cpp
@@ -68,6 +68,10 @@ rtDefineProperty(pxConstantsAnimation, OPTION_FASTFORWARD);
 rtDefineProperty(pxConstantsAnimation, OPTION_REWIND);
 rtDefineProperty(pxConstantsAnimation, COUNT_FOREVER);
 rtDefineProperty(pxConstantsAnimation, interpolators);
+rtDefineProperty(pxConstantsAnimation, STATUS_IDLE);
+rtDefineProperty(pxConstantsAnimation, STATUS_INPROGRESS);
+rtDefineProperty(pxConstantsAnimation, STATUS_CANCELLED);
+rtDefineProperty(pxConstantsAnimation, STATUS_ENDED);
 // Constants for Stretch
 rtDefineObject(pxConstantsStretch, rtObject);
 rtDefineProperty(pxConstantsStretch,NONE);

--- a/examples/pxScene2d/src/pxConstants.h
+++ b/examples/pxScene2d/src/pxConstants.h
@@ -60,6 +60,13 @@ public:
     COUNT_FOREVER = -1
   };
 
+  enum animationStatus {
+    STATUS_IDLE = 0,
+    STATUS_INPROGRESS,
+    STATUS_CANCELLED,
+    STATUS_ENDED
+  };
+
   rtDeclareObject(pxConstantsAnimation, rtObject);
   
   rtConstantProperty(TWEEN_LINEAR, TWEEN_LINEAR, uint32_t);
@@ -81,6 +88,11 @@ public:
   rtConstantProperty(OPTION_FASTFORWARD, OPTION_FASTFORWARD, uint32_t);
   rtConstantProperty(OPTION_REWIND, OPTION_REWIND, uint32_t);
   rtConstantProperty(COUNT_FOREVER, COUNT_FOREVER, int32_t);
+
+  rtConstantProperty(STATUS_IDLE, STATUS_IDLE, uint32_t);
+  rtConstantProperty(STATUS_INPROGRESS, STATUS_INPROGRESS, uint32_t);
+  rtConstantProperty(STATUS_CANCELLED, STATUS_CANCELLED, uint32_t);
+  rtConstantProperty(STATUS_ENDED, STATUS_ENDED, uint32_t);
 
   rtReadOnlyProperty(interpolators, interpolators, rtObjectRef);
   

--- a/examples/pxScene2d/src/pxScene2d.h
+++ b/examples/pxScene2d/src/pxScene2d.h
@@ -57,7 +57,7 @@
 #include "pxContextFramebuffer.h"
 
 #include "pxArchive.h"
-
+#include "pxAnimate.h"
 #include "testView.h"
 
 #ifdef ENABLE_RT_NODE
@@ -123,6 +123,7 @@ struct animation
   bool reversing;
   rtFunctionRef ended;
   rtObjectRef promise;
+  rtObjectRef animateObj;
 };
 
 struct pxPoint2f 
@@ -181,6 +182,8 @@ public:
   rtMethod5ArgAndReturn("animateTo", animateToP2, rtObjectRef, double,
                         uint32_t, uint32_t, int32_t, rtObjectRef);
 
+  rtMethod5ArgAndReturn("animate", animateToObj, rtObjectRef, double,
+                        uint32_t, uint32_t, int32_t, rtObjectRef);
   rtMethod2ArgAndNoReturn("on", addListener, rtString, rtFunctionRef);
   rtMethod2ArgAndNoReturn("delListener", delListener, rtString, rtFunctionRef);
   rtMethodNoArgAndNoReturn("dispose",releaseResources);
@@ -397,9 +400,13 @@ public:
                       uint32_t interp, uint32_t animationType,
                       int32_t count, rtObjectRef& promise);
 
+  rtError animateToObj(rtObjectRef props, double duration,
+                      uint32_t interp, uint32_t animationType,
+                      int32_t count, rtObjectRef& promise);
+
   void animateToInternal(const char* prop, double to, double duration,
                  pxInterp interp, pxConstantsAnimation::animationOptions,
-                 int32_t count, rtObjectRef promise);
+                 int32_t count, rtObjectRef promise, rtObjectRef animateObj);
 
   void cancelAnimation(const char* prop, bool fastforward = false, bool rewind = false, bool resolve = false);
 


### PR DESCRIPTION
With this, below way of animation is introduced:

var animateObj = obj.animate();
animateObj.done.then();

Animation can be cancelled as below:
animateObj.cancel - true;

Below are the properties that can be queried:
done -> promise to indicate completion of animation
type -> type of animation
interp -> interpolators of animation
status -> status of animation IDLE,INPROGRESS,ENDED,CANCELLED
provduration -> provisioned duration of animation by end user
provcount -> provisioned count of animation by end user
cancel -> status of animation, is it cancelled or not
props -> properties added for animation like x,y etc
details -> details of status of animation of every property.
