### PR TITLE
Make for X11 on Linux failed due on missing symbol

### DIFF
--- a/src/x11/pxWindowNative.cpp
+++ b/src/x11/pxWindowNative.cpp
@@ -7,6 +7,7 @@
 #include "pxWindowNative.h"
 #include "../pxTimer.h"
 #include "../pxWindowUtil.h"
+#include "../pxKeycodes.h"
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
The fix was to include the file containing the symbol.

System experiencing failure was Fedora 25.