### PR TITLE
Update waylandregistry mechanism

### DIFF
--- a/examples/pxScene2d/src/pxWaylandContainer.cpp
+++ b/examples/pxScene2d/src/pxWaylandContainer.cpp
@@ -159,7 +159,7 @@ rtError pxWaylandContainer::setCmd(const char* s)
   if (it != gWaylandAppsMap.end())
   {
     binary = it->second.c_str();
-    rtLogInfo( "waylandregistry.conf maps wayland app \"%s\ to \"%s\"\n",s, it->second.c_str());
+    rtLogInfo( "waylandregistry.conf maps wayland app \"%s\" to \"%s\"\n",s, it->second.c_str());
   }
   else
   {

--- a/examples/pxScene2d/src/pxWaylandContainer.cpp
+++ b/examples/pxScene2d/src/pxWaylandContainer.cpp
@@ -159,11 +159,11 @@ rtError pxWaylandContainer::setCmd(const char* s)
   if (it != gWaylandAppsMap.end())
   {
     binary = it->second.c_str();
+    rtLogInfo( "waylandregistry.conf maps wayland app \"%s\ to \"%s\"\n",s, it->second.c_str());
   }
   else
   {
-    rtLogError("Unrecognised wayland app \"%s\". please verify the app name or add entry in waylandregistry.conf \n",s);
-    return RT_ERROR;
+    binary = s;
   }
 
   if ( mWayland )


### PR DESCRIPTION
In order to facilitate Westeros CTS testing, the waylandregistry mechanism is updated to behave as it does now if a registry match is found, but if no match is found, to use the cmd string as-is.

Signed-off-by: Jeff Wannamaker <jeff_wannamaker@cable.comcast.com>