### PR TITLE
Update wayland registry to allow arguments

### DIFF
--- a/examples/pxScene2d/src/waylandregistry.conf
+++ b/examples/pxScene2d/src/waylandregistry.conf
@@ -7,6 +7,14 @@
     {
       "name" : "netflix",
       "binary" : "/usr/bin/nrdPluginApp"
+    },
+    {
+      "name" : "westeros_test",
+      "binary" : "/usr/bin/westeros_test%"
+    },
+    {
+      "name" : "gst-launch-1.0",
+      "binary" : "/usr/bin/gst-launch-1.0%"
     }
   ]
 }


### PR DESCRIPTION
Wayland registry entries with a '%' suffix on the specified binary will now allow arguments.  The command supplied by JavaScript excluding any arguments will be used as the registry search key and the regstry binary will be invoked with the supplied arguments.
Added entries to waylandregistry.conf for westeros_test and gst-launch allowing arguments

Signed-off-by: Jeff Wannamaker <jeff_wannamaker@cable.comcast.com>