### PR TITLE
Kill wayland client if necessary

### DIFF
--- a/tests/pxScene2d/CMakeLists.txt
+++ b/tests/pxScene2d/CMakeLists.txt
@@ -51,7 +51,7 @@ endif (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
 add_definitions(-D${PX_PLATFORM} -DENABLE_RT_NODE -DRUNINMAIN -DENABLE_HTTP_CACHE)
 
 set(TEST_SOURCE_FILES pxscene2dtestsmain.cpp test_example.cpp test_api.cpp test_pxcontext.cpp test_memoryleak.cpp test_rtnode.cpp
-        test_pxAnimate.cpp test_jsfiles.cpp)
+        test_pxAnimate.cpp test_jsfiles.cpp test_pxWayland.cpp)
 
 if (DEFINED ENV{USE_HTTP_CACHE})
     message("Include http cache tests")

--- a/tests/pxScene2d/Makefile
+++ b/tests/pxScene2d/Makefile
@@ -18,7 +18,8 @@ SRCS_FULL=\
     test_rtZip.cpp \
     test_rtString.cpp \
     test_pxUtil.cpp \
-    test_pxImage.cpp 
+    test_pxImage.cpp \
+    test_pxWayland.cpp
 
 MAKEFILE_PATH:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 PXCOREDIR=$(MAKEFILE_PATH)/../../
@@ -47,7 +48,8 @@ SEARCH=\
         -I$(EXTDIR)/gtest/googletest \
         -I$(EXTDIR)/gtest/googlemock/include \
         -I$(EXTDIR)/gtest/googlemock \
-        -I$(EXTDIR)/curl/include
+        -I$(EXTDIR)/curl/include \
+        -I$(EXTDIR)/westeros-stub
 ifeq ($(USE_EXTERNALS_GLUT), true)
 SEARCH += -I$(EXTDIR)/freeglut/include
 endif

--- a/tests/pxScene2d/test_pxWayland.cpp
+++ b/tests/pxScene2d/test_pxWayland.cpp
@@ -1,0 +1,114 @@
+#include "pxWayland.h"
+
+#include "test_includes.h" // Needs to be included last
+
+using namespace std;
+
+class pxWaylandTest : public testing::Test
+{
+  public:
+    virtual void SetUp()
+    {
+       mWayland= new pxWayland();
+    }
+    
+    virtual void TearDown()
+    {
+       if ( mWayland )
+       {
+          delete mWayland;
+          mWayland= NULL;
+       }
+    }
+
+    void initialNameTest()
+    {
+      rtError err;
+      rtString s;
+      
+      err= mWayland->displayName( s );
+      EXPECT_TRUE( err == RT_OK );
+      EXPECT_STREQ( "", (const char*)s );
+    }
+    
+    void setNameTest()
+    {
+      rtError err;
+      rtString s;
+
+      err= mWayland->setDisplayName( "foo0" );
+      EXPECT_TRUE( err == RT_OK );
+            
+      err= mWayland->displayName( s );
+      EXPECT_TRUE( err == RT_OK );
+      EXPECT_STREQ( "foo0", (const char*)s );
+    }
+    
+    void autoNameTest()
+    {
+      rtError err;
+      rtString s;
+      
+      mWayland->onSize(100,100);
+      mWayland->onInit();
+      err= mWayland->displayName( s );
+      EXPECT_TRUE( err == RT_OK );
+      EXPECT_TRUE( !s.isEmpty() );
+      printf("name=%s\n", (const char*)s );
+    }
+
+    void initialCmdTest()
+    {
+      rtError err;
+      rtString s;
+      
+      err= mWayland->cmd( s );
+      EXPECT_TRUE( err == RT_OK );
+      EXPECT_STREQ( "", (const char*)s );
+    }
+    
+    void setCmdTest()
+    {
+      rtError err;
+      rtString s;
+
+      err= mWayland->setCmd( "rmfPlayer" );
+      EXPECT_TRUE( err == RT_OK );
+            
+      err= mWayland->cmd( s );
+      EXPECT_TRUE( err == RT_OK );
+      EXPECT_STREQ( "rmfPlayer", (const char*)s );
+    }
+
+    void initialHasAPITest()
+    {
+      rtError err;
+      bool hasAPI;
+      
+      err= mWayland->hasApi( hasAPI );
+      EXPECT_TRUE( err == RT_OK );
+      EXPECT_TRUE( false == hasAPI );
+    }
+    
+private:
+  pxWayland *mWayland;
+};
+
+TEST_F( pxWaylandTest, nameTests )
+{
+   initialNameTest();
+   autoNameTest();
+   setNameTest();
+}
+
+TEST_F( pxWaylandTest, cmdTests )
+{
+   initialCmdTest();
+   setCmdTest();
+}
+
+TEST_F( pxWaylandTest, apiTests )
+{
+   initialHasAPITest();
+}
+


### PR DESCRIPTION
When a pxWayland instance is destroyed, it stops and destroys its Westeros compositor instance and this will usually trigger the exit of any client process attached to the compositor.  It is possible that the client will not exit, however, so code is added to explicitly kill the client process if it does not exit on its own

Signed-off-by: Jeff Wannamaker <jeff_wannamaker@cable.comcast.com>